### PR TITLE
Fix Shift+Enter not inserting newline in CLI agents

### DIFF
--- a/public/js/hotkeys.js
+++ b/public/js/hotkeys.js
@@ -88,6 +88,13 @@ export function unregisterAllForPlugin(pluginId) {
 // Prompt autocomplete (// trigger) runs first, then hotkey dispatch.
 export function attachToTerminal(term) {
   term.attachCustomKeyEventHandler((e) => {
+    // Shift+Enter: send CSI u escape sequence so CLI agents (Claude Code etc.)
+    // can distinguish it from plain Enter and insert a newline.
+    if (e.type === 'keydown' && e.key === 'Enter' && e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey) {
+      e.preventDefault();
+      term.input('\x1b[13;2u', true);
+      return false;
+    }
     const promptResult = handleTerminalKey(e);
     if (promptResult === false) return false;
     if (e.type !== 'keydown') return true;


### PR DESCRIPTION
## Summary
- xterm.js sends `\r` for both Enter and Shift+Enter, making them indistinguishable at the PTY level
- CLI agents like Claude Code use Shift+Enter for multiline input (newline), but receive a plain Enter instead — causing immediate submission
- This intercepts Shift+Enter in `attachCustomKeyEventHandler` and sends the CSI u escape sequence (`\x1b[13;2u`) via xterm's public `input()` API, so agents can recognize the modifier and insert a newline

## Test plan
- [ ] Open a Claude Code session in CliDeck
- [ ] Press Shift+Enter — should insert a newline, not submit
- [ ] Press Enter — should still submit as before
- [ ] Verify other Shift+ hotkeys still work (e.g. Ctrl+Shift+K for clear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)