### PR TITLE
Fix npx assets and HTTPS WebSocket support

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,5 +1,6 @@
 const { readFileSync, writeFileSync, existsSync } = require('fs');
 const { join } = require('path');
+const crypto = require('crypto');
 const os = require('os');
 const { DATA_DIR } = require('./paths');
 const { defaultShell, binName } = require('./utils');

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -17,7 +17,8 @@ const shownAgentHealthToasts = new Set();
 let reconnectReplaySkip = null;
 
 function connect() {
-  state.ws = new WebSocket(`ws://${location.host}`);
+  const wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  state.ws = new WebSocket(`${wsProtocol}//${location.host}`);
 
   state.ws.onopen = () => {
     reconnectReplaySkip = new Set(state.terms.keys());

--- a/server.js
+++ b/server.js
@@ -61,9 +61,9 @@ const hostArg = hostIdx >= 0 ? process.argv[hostIdx + 1] : undefined;
 const HOST = hostIdx < 0 ? '127.0.0.1' : (hostArg && !hostArg.startsWith('-') ? hostArg : '0.0.0.0');
 const MIME = { '.html': 'text/html', '.css': 'text/css', '.js': 'application/javascript', '.png': 'image/png', '.svg': 'image/svg+xml', '.mp3': 'audio/mpeg' };
 const ALIASES = {
-  '/xterm.css':    join(__dirname, 'node_modules/@xterm/xterm/css/xterm.css'),
-  '/xterm.js':     join(__dirname, 'node_modules/@xterm/xterm/lib/xterm.js'),
-  '/addon-fit.js': join(__dirname, 'node_modules/@xterm/addon-fit/lib/addon-fit.js'),
+  '/xterm.css':    require.resolve('@xterm/xterm/css/xterm.css'),
+  '/xterm.js':     require.resolve('@xterm/xterm/lib/xterm.js'),
+  '/addon-fit.js': require.resolve('@xterm/addon-fit/lib/addon-fit.js'),
 };
 
 const PUBLIC_ROOT = join(__dirname, 'public');
@@ -251,6 +251,9 @@ const server = http.createServer((req, res) => {
 const allowedOrigins = new Set([
   `http://localhost:${PORT}`, `http://127.0.0.1:${PORT}`,
   `http://[::1]:${PORT}`, `http://${HOST}:${PORT}`,
+  `https://localhost:${PORT}`, `https://127.0.0.1:${PORT}`,
+  `https://[::1]:${PORT}`, `https://${HOST}:${PORT}`,
+  `https://${HOST}`,
 ]);
 const wss = new WebSocketServer({
   server,

--- a/sessions.js
+++ b/sessions.js
@@ -1,6 +1,7 @@
 const pty = require('node-pty');
 const { readFileSync, writeFileSync, existsSync } = require('fs');
 const { join } = require('path');
+const crypto = require('crypto');
 const { parseCommand, resolveValidDir, defaultShell, binName } = require('./utils');
 const activity = require('./activity');
 const transcript = require('./transcript');


### PR DESCRIPTION
## Summary
- Import Node crypto where `crypto.randomUUID()` is used in CommonJS modules.
- Resolve xterm static assets with `require.resolve()` so `npx` hoisted installs work.
- Use `wss://` from HTTPS pages and allow matching HTTPS origins.

## Why
When running through `npx clideck`, selecting an agent can crash on Node 18 with `ReferenceError: crypto is not defined`. Also, xterm
assets can 404 because dependencies are hoisted outside `clideck/node_modules`. HTTPS reverse-proxy usage also needs WSS instead of
relying on CSP upgrades.

## Test
- `npm ci`
- `node -c config.js`
- `node -c sessions.js`
- `node -c server.js`
- `npm run build:css`
