### PR TITLE
fix(roles): wire up roles panel and session role assignment

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -147,6 +147,9 @@
     <button class="rail-btn w-9 h-9 flex items-center justify-center rounded-lg text-slate-500 hover:text-slate-300 hover:bg-slate-800/50 transition-colors" data-panel="prompts" title="Prompt Library">
       <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="M16 13H8"/><path d="M16 17H8"/></svg>
     </button>
+    <button class="rail-btn w-9 h-9 flex items-center justify-center rounded-lg text-slate-500 hover:text-slate-300 hover:bg-slate-800/50 transition-colors" data-panel="roles" title="Roles">
+      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+    </button>
     <button class="rail-btn w-9 h-9 flex items-center justify-center rounded-lg text-slate-500 hover:text-slate-300 hover:bg-slate-800/50 transition-colors" data-panel="plugins" title="Plugins">
       <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v4m0 12v4M2 12h4m12 0h4"/><circle cx="12" cy="12" r="3"/><path d="M12 8V6m0 12v-2M8 12H6m12 0h-2"/></svg>
     </button>
@@ -197,6 +200,8 @@
     </div>
     <!-- Prompts panel (rendered by prompts.js) -->
     <div id="panel-prompts" class="hidden flex-col flex-1 min-h-0"></div>
+    <!-- Roles panel (rendered by roles.js) -->
+    <div id="panel-roles" class="hidden flex-col flex-1 min-h-0"></div>
     <!-- Plugins panel -->
     <div id="panel-plugins" class="hidden flex-col flex-1 min-h-0">
       <div class="flex items-center px-4 py-3 border-b border-slate-700/50">

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -12,6 +12,7 @@ import './nav.js';
 import { initDrag, wasDragging } from './drag.js';
 import { registerHotkey, unregisterHotkey, unregisterAllForPlugin } from './hotkeys.js';
 import { renderPrompts } from './prompts.js';
+import { renderRoles } from './roles.js';
 
 const shownAgentHealthToasts = new Set();
 let reconnectReplaySkip = null;
@@ -34,6 +35,7 @@ function connect() {
         regroupSessions();
         renderSettings();
         renderPrompts();
+        renderRoles();
         refreshCreator();
         for (const [, entry] of state.terms) applyTheme(entry.term, entry.themeId);
         break;

--- a/public/js/creator.js
+++ b/public/js/creator.js
@@ -102,10 +102,9 @@ function sortedPresets() {
   return [...agents, ...shell];
 }
 
-function createFromPreset(preset, sessionName, cwd, projectId) {
-  // Find existing command matching this preset
+function createFromPreset(preset, sessionName, cwd, projectId, role) {
   const cmd = ensureCommandForPreset(preset);
-  send({ type: 'create', commandId: cmd.id, name: sessionName, cwd, projectId: projectId || undefined, ...estimateSize() });
+  send({ type: 'create', commandId: cmd.id, name: sessionName, cwd, projectId: projectId || undefined, roleId: role?.id, ...estimateSize() });
   localStorage.setItem(MRU_KEY, preset.presetId);
 }
 
@@ -196,6 +195,13 @@ export function openCreator() {
     <div class="text-[10px] font-semibold uppercase tracking-wider text-slate-500 mb-1.5">Session name</div>
     <input id="creator-name" type="text" maxlength="35" placeholder="Session name"
       class="w-full px-3 py-2 text-sm bg-slate-900 border border-slate-700 rounded-md text-slate-200 placeholder-slate-500 outline-none focus:border-blue-500 transition-colors mb-2">
+    ${(state.cfg.roles?.length) ? `
+    <div class="text-[10px] font-semibold uppercase tracking-wider text-slate-500 mb-1.5">Role <span class="normal-case font-normal text-slate-600">— optional</span></div>
+    <input type="hidden" id="creator-role" value="">
+    <button type="button" id="creator-role-trigger" class="w-full px-3 py-1.5 text-xs bg-slate-900 border border-slate-700 rounded-md text-slate-400 text-left flex items-center justify-between outline-none hover:border-slate-500 transition-colors cursor-pointer mb-2">
+      <span id="creator-role-label">No role</span>
+      <span class="text-slate-600 ml-2">&#9662;</span>
+    </button>` : ''}
     <div id="creator-cwd-wrap" class="flex items-center gap-1.5 mb-2 ${(state.cfg.projects?.length) ? 'hidden' : ''}">
       <input id="creator-cwd" type="text" value="${esc(defaultPath)}" placeholder="Working directory"
         class="flex-1 px-3 py-1.5 text-xs bg-slate-900 border border-slate-700 rounded-md text-slate-400 placeholder-slate-600 outline-none focus:border-blue-500 transition-colors font-mono">
@@ -298,6 +304,50 @@ export function openCreator() {
     });
   }
 
+  // Role picker dropdown
+  const roleTrigger = card.querySelector('#creator-role-trigger');
+  const roleHidden = card.querySelector('#creator-role');
+  if (roleTrigger) {
+    const roles = state.cfg.roles || [];
+    const roleLabel = card.querySelector('#creator-role-label');
+    let rolMenuCleanup = null;
+    roleTrigger.addEventListener('click', () => {
+      if (rolMenuCleanup) { rolMenuCleanup(); return; }
+      const rect = roleTrigger.getBoundingClientRect();
+      const menu = document.createElement('div');
+      menu.className = 'fixed z-[500] bg-slate-800 border border-slate-600 rounded-lg shadow-xl shadow-black/40 py-1 overflow-y-auto';
+      menu.style.maxHeight = '200px';
+      menu.style.left = rect.left + 'px';
+      menu.style.top = (rect.bottom + 4) + 'px';
+      menu.style.width = rect.width + 'px';
+      menu.innerHTML = `
+        <div class="role-option px-3 py-1.5 cursor-pointer hover:bg-slate-700 transition-colors text-xs text-slate-400 ${!roleHidden.value ? 'bg-slate-700/50' : ''}" data-value="">No role</div>
+        ${roles.map(r => `
+          <div class="role-option px-3 py-1.5 cursor-pointer hover:bg-slate-700 transition-colors text-xs text-slate-300 ${roleHidden.value === r.id ? 'bg-slate-700/50' : ''}" data-value="${r.id}">${esc(r.name)}</div>`).join('')}`;
+      document.body.appendChild(menu);
+      const onClick = (e) => {
+        const item = e.target.closest('.role-option');
+        if (!item) return;
+        const role = roles.find(r => r.id === item.dataset.value);
+        roleHidden.value = item.dataset.value;
+        roleLabel.textContent = role ? role.name : 'No role';
+        if (role && !nameInput.value.trim()) nameInput.value = role.name;
+        rolMenuCleanup();
+      };
+      const onOutside = (e) => {
+        if (!menu.contains(e.target) && !roleTrigger.contains(e.target)) rolMenuCleanup();
+      };
+      menu.addEventListener('click', onClick);
+      requestAnimationFrame(() => document.addEventListener('click', onOutside));
+      rolMenuCleanup = () => {
+        menu.removeEventListener('click', onClick);
+        document.removeEventListener('click', onOutside);
+        menu.remove();
+        rolMenuCleanup = null;
+      };
+    });
+  }
+
   // "Add" button for missing agents — opens install toaster
   card.addEventListener('click', (e) => {
     const installBtn = e.target.closest('.install-btn');
@@ -326,7 +376,8 @@ export function openCreator() {
     const name = nameInput.value.trim() || fallbackName;
     const cwd = cwdInput.value.trim() || undefined;
     const projectId = projHidden?.value && projHidden.value !== NO_PROJECT_VALUE ? projHidden.value : undefined;
-    createFromPreset(preset, name, cwd, projectId);
+    const role = roleHidden?.value ? (state.cfg.roles || []).find(r => r.id === roleHidden.value) : undefined;
+    createFromPreset(preset, name, cwd, projectId, role);
     closeCreator();
   });
 }

--- a/public/js/nav.js
+++ b/public/js/nav.js
@@ -1,8 +1,8 @@
 import { closeThemeMenu } from './settings.js';
 import { closeDropdown } from './prompts.js';
 
-const ALL_PANELS = ['chats', 'prompts', 'plugins', 'settings'];
-const PANEL_TITLES = { chats: 'Sessions', prompts: 'Prompts', plugins: 'Plugins', settings: 'Settings' };
+const ALL_PANELS = ['chats', 'prompts', 'roles', 'plugins', 'settings'];
+const PANEL_TITLES = { chats: 'Sessions', prompts: 'Prompts', roles: 'Roles', plugins: 'Plugins', settings: 'Settings' };
 const ACTIVE = ['text-slate-200', 'bg-slate-800'];
 const INACTIVE = ['text-slate-500', 'hover:text-slate-300', 'hover:bg-slate-800/50'];
 


### PR DESCRIPTION
Closes #13

## What changed

Two things were broken with the Roles feature — the panel was unreachable from the UI, and there was no way to assign a role when starting a session.

- Added `'roles'` to `ALL_PANELS` and `PANEL_TITLES` in `nav.js` so the sidebar rail registers and titles the panel correctly
- Added the `panel-roles` div to `index.html` so the DOM element exists for `roles.js` to render into
- Added a Roles rail button (person icon) to the sidebar between Prompt Library and Plugins
- Imported `renderRoles` in `app.js` and called it alongside `renderPrompts` on config load
- Added a Role dropdown to the session creator (only shown when at least one role is defined), which auto-fills the session name on selection and passes `roleId` to the `create` message so the server handles injection and persists `roleName`

## Why

The `roles.js` file, server-side `roleId` handling, and `roleName` session field were all already implemented, but the panel had no HTML element, no nav entry, and no way to reach it. The session creator had no role picker either.

## How to verify

1. Run `node server.js` and open `http://localhost:4000`
2. A person icon should appear in the sidebar rail between Prompt Library and Plugins — clicking it opens the Roles panel where you can create, edit, and delete roles
3. Click **+** to open the session creator — if at least one role exists, a Role dropdown appears below the session name field; selecting a role auto-fills the name
4. Start a session with a role selected — the role's instructions are injected after startup and `roleName` is persisted in `sessions.json`

## What's out of scope

- Displaying the assigned role name in the session list/sidebar (cosmetic follow-up)
- Role assignment for sessions created via plugins or `clideck ask`