### PR TITLE
Fix malformed terminal display on browser reconnect

### DIFF
--- a/handlers.js
+++ b/handlers.js
@@ -284,7 +284,11 @@ function onConnection(ws) {
             // if (sess.presetId === 'claude-code') {
             //   console.log(`[claude] terminal.buffer finalize session=${msg.id.slice(0,8)} lines=${msg.lines?.length || 0}`);
             // }
-            transcript.commitAgentCandidate(msg.id, sess.presetId);
+            const committed = transcript.commitAgentCandidate(msg.id, sess.presetId);
+            if (committed) {
+              const updatedText = transcript.getReplayText(msg.id, sess.presetId);
+              if (updatedText) sessions.broadcast({ type: 'session.history', id: msg.id, text: updatedText, replace: true });
+            }
           }
           let choices = require('./transcript').detectMenu(msg.lines, sess.presetId);
           // Codex: only trust menu detection if last OTEL event was response.completed

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -110,7 +110,10 @@ function connect() {
       case 'session.history': {
         const entry = state.terms.get(msg.id);
         if (msg.replay && reconnectReplaySkip?.has(msg.id) && entry) break;
-        if (msg.replace && entry?.term) entry.term.reset();
+        // replace:true is sent after idle-finalization commits a cleaner transcript. Skip
+        // the reset+replay for live sessions — resetting xterm while the PTY is still alive
+        // desyncs the display from the PTY's cursor state, garbling subsequent output.
+        if (msg.replace) { updatePreview(msg.id); break; }
         const histText = (msg.text + '\n').replace(/(?<!\r)\n/g, '\r\n');
         if (entry && !entry.queue(histText)) entry.term.write(histText);
         updatePreview(msg.id);

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -110,7 +110,8 @@ function connect() {
       case 'session.history': {
         const entry = state.terms.get(msg.id);
         if (msg.replay && reconnectReplaySkip?.has(msg.id) && entry) break;
-        if (entry && !entry.queue(msg.text + '\n')) entry.term.write(msg.text + '\n');
+        const histText = (msg.text + '\n').replace(/(?<!\r)\n/g, '\r\n');
+        if (entry && !entry.queue(histText)) entry.term.write(histText);
         updatePreview(msg.id);
         break;
       }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -110,6 +110,7 @@ function connect() {
       case 'session.history': {
         const entry = state.terms.get(msg.id);
         if (msg.replay && reconnectReplaySkip?.has(msg.id) && entry) break;
+        if (msg.replace && entry?.term) entry.term.reset();
         const histText = (msg.text + '\n').replace(/(?<!\r)\n/g, '\r\n');
         if (entry && !entry.queue(histText)) entry.term.write(histText);
         updatePreview(msg.id);

--- a/transcript.js
+++ b/transcript.js
@@ -230,6 +230,7 @@ function getCache() { return { ...cache }; }
 function getReplayText(id, presetId) {
   const entries = builder.compactEntries(entriesById[id], presetId);
   if (!entries?.length) return '';
+  if (!entries.some(e => e.role === 'agent')) return '';
   const marks = {
     'claude-code': { user: '❯', agent: '⏺' },
     codex: { user: '›', agent: '•' },

--- a/transcript.js
+++ b/transcript.js
@@ -171,12 +171,13 @@ function updateAgentCandidate(id, presetId, lines) {
 }
 
 function commitAgentCandidate(id, presetId) {
-  if (!finalizePreset[id]) return;
+  if (!finalizePreset[id]) return false;
   const text = candidate.get(id);
-  if (!text) { tlog(id, 'candidate commit skip empty'); clog(id, 'candidate commit skip empty'); return; }
-  if (text === lastAgentText[id]) { tlog(id, 'candidate commit skip duplicate'); clog(id, 'candidate commit skip duplicate'); return; }
+  if (!text) { tlog(id, 'candidate commit skip empty'); clog(id, 'candidate commit skip empty'); return false; }
+  if (text === lastAgentText[id]) { tlog(id, 'candidate commit skip duplicate'); clog(id, 'candidate commit skip duplicate'); return false; }
   lastAgentText[id] = text;
   store(id, 'agent', text);
+  return true;
 }
 
 function clearAgentCandidate(id) {


### PR DESCRIPTION
## Summary

- **Fix CRLF rendering**: \`getReplayText\` produced bare \`\n\` line endings; xterm.js treats these as LF-only (no carriage return), causing user prompts to staircase across the screen. Fixed by normalizing to \`\r\n\` in the \`session.history\` client handler.
- **Fix missing agent responses (root cause)**: When the transcript had only user entries (no agent responses committed yet), \`getReplayText\` still returned a non-empty string. \`sendBuffers\` sent it as \`session.history\` and skipped the raw PTY chunks — which actually contain the full conversation. Fixed by returning \`''\` from \`getReplayText\` when no agent entries exist, so the fallback to raw PTY chunks kicks in.
- **Broadcast clean transcript after agent commit**: When \`commitAgentCandidate\` succeeds, broadcast an updated \`session.history\` with \`replace: true\` to all connected clients so they re-render with the clean transcript format.
- **Fix terminal desync on idle (Zzz state)**: The \`replace: true\` broadcast triggered \`term.reset()\` in the client even for live sessions. Resetting xterm while the PTY is still alive desyncs the display from the PTY's cursor state — causing subsequent output (Claude's responses) to render garbled or invisible until Ctrl+L. Fixed by skipping the reset+replay entirely for \`replace: true\` messages; the transcript is already committed server-side and live sessions already show correct PTY output.

## Test plan

- [ ] Reload the browser mid-conversation and verify all Claude responses are visible
- [ ] Verify user prompts display without staircase formatting after reload
- [ ] Open two tabs on the same session — after Claude finishes a response, both tabs should update to show the clean \`❯\`/\`⏺\` transcript format
- [ ] Let a session go idle (Zzz) and type a new prompt — verify Claude's response appears correctly without needing Ctrl+L