### PR TITLE
fix: settings category switch doesn't scroll to top; send() throws on WS reconnect

### DIFF
--- a/handlers.js
+++ b/handlers.js
@@ -475,6 +475,10 @@ function onConnection(ws) {
           ws.send(JSON.stringify({ type: 'project.openPath.result', id: msg.id, success: false, error: 'Project path is not set' }));
           break;
         }
+        if (process.platform === 'linux' && !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) {
+          ws.send(JSON.stringify({ type: 'project.openPath.result', id: msg.id, success: false, error: `No display available — path: ${proj.path}` }));
+          break;
+        }
         const cmd = process.platform === 'darwin'
           ? 'open'
           : process.platform === 'win32'

--- a/handlers.js
+++ b/handlers.js
@@ -476,7 +476,7 @@ function onConnection(ws) {
           break;
         }
         if (process.platform === 'linux' && !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) {
-          ws.send(JSON.stringify({ type: 'project.openPath.result', id: msg.id, success: false, error: `No display available — path: ${proj.path}` }));
+          ws.send(JSON.stringify({ type: 'project.openPath.result', id: msg.id, success: false, headless: true, path: proj.path }));
           break;
         }
         const cmd = process.platform === 'darwin'

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -264,7 +264,16 @@ function connect() {
         break;
       }
       case 'project.openPath.result':
-        if (!msg.success) showToast(msg.error || 'Failed to open project folder', { type: 'error' });
+        if (!msg.success) {
+          if (msg.headless && msg.path && navigator.clipboard) {
+            navigator.clipboard.writeText(msg.path).then(
+              () => showToast(msg.path, { title: 'Path copied to clipboard', duration: 4000 }),
+              () => showToast(msg.path, { title: 'No file manager — project path', duration: 8000 }),
+            );
+          } else {
+            showToast(msg.error || 'Failed to open project folder', { type: 'error' });
+          }
+        }
         break;
       case 'sessions.saved':
         flashSaveIndicator();

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,5 +1,5 @@
 import { state, send } from './state.js';
-import { esc, binName, resolveIconPath } from './utils.js';
+import { esc, binName, resolveIconPath, randomUUID } from './utils.js';
 import { addTerminal, removeTerminal, select, startRename, startProjectRename, setSessionTheme, openMenu, closeMenu, setStatus, updateMuteIndicator, updatePreview, markUnread, applyFilter, setTab, renderResumable, regroupSessions, toggleProjectCollapse, setSessionProject, estimateSize, restartComplete, positionMenu, addPill, updatePill, removePill, appendPillLog, setPillLogs, closePillLog } from './terminals.js';
 import { renderSettings, updateVersionFooter } from './settings.js';
 import { openCreator, closeCreator, refreshCreator } from './creator.js';
@@ -756,7 +756,7 @@ function openProjectCreator() {
     if (!name) { nameInput.focus(); return; }
     const projects = state.cfg.projects || [];
     projects.push({
-      id: crypto.randomUUID(),
+      id: randomUUID(),
       name,
       path: path || undefined,
       color: PROJECT_COLORS[projects.length % PROJECT_COLORS.length],

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -265,11 +265,24 @@ function connect() {
       }
       case 'project.openPath.result':
         if (!msg.success) {
-          if (msg.headless && msg.path && navigator.clipboard) {
-            navigator.clipboard.writeText(msg.path).then(
-              () => showToast(msg.path, { title: 'Path copied to clipboard', duration: 4000 }),
-              () => showToast(msg.path, { title: 'No file manager — project path', duration: 8000 }),
-            );
+          if (msg.headless && msg.path) {
+            const copied = (() => {
+              if (navigator.clipboard) {
+                navigator.clipboard.writeText(msg.path).catch(() => {});
+                return true;
+              }
+              try {
+                const ta = document.createElement('textarea');
+                ta.value = msg.path;
+                ta.style.cssText = 'position:fixed;opacity:0';
+                document.body.appendChild(ta);
+                ta.select();
+                const ok = document.execCommand('copy');
+                ta.remove();
+                return ok;
+              } catch { return false; }
+            })();
+            showToast(msg.path, { title: copied ? 'Path copied to clipboard' : 'No file manager — project path', duration: copied ? 4000 : 8000 });
           } else {
             showToast(msg.error || 'Failed to open project folder', { type: 'error' });
           }

--- a/public/js/creator.js
+++ b/public/js/creator.js
@@ -1,5 +1,5 @@
 import { state, send } from './state.js';
-import { esc, agentIcon, binName } from './utils.js';
+import { esc, agentIcon, binName, randomUUID } from './utils.js';
 import { openFolderPicker } from './folder-picker.js';
 import { estimateSize } from './terminals.js';
 import { showToast } from './toast.js';
@@ -130,7 +130,7 @@ function ensureCommandForPreset(preset) {
   let cmd = findCommandForPreset(preset);
   if (cmd) return cmd;
   cmd = {
-    id: crypto.randomUUID(),
+    id: randomUUID(),
     presetId: preset.presetId,
     label: preset.name,
     icon: preset.icon,
@@ -166,7 +166,7 @@ function ensureShellCommand() {
   }
   if (!command) return null;
   cmd = {
-    id: crypto.randomUUID(),
+    id: randomUUID(),
     presetId: 'shell',
     label: 'Shell',
     icon: shellPreset?.icon || 'terminal',
@@ -408,7 +408,7 @@ function showInstallToast(preset) {
       showToast('Could not find a shell command to run the installer.', { type: 'error', title: 'Install Failed' });
       return;
     }
-    const installId = crypto.randomUUID();
+    const installId = randomUUID();
     send({ type: 'create', commandId: shellCmd.id, name: `Installing ${preset.name}`, installId, ...estimateSize() });
     const handler = (e) => {
       const msg = JSON.parse(e.data);

--- a/public/js/prompts.js
+++ b/public/js/prompts.js
@@ -1,6 +1,6 @@
 // Prompt Library — manage saved prompts and // trigger autocomplete
 import { state, send } from './state.js';
-import { esc } from './utils.js';
+import { esc, randomUUID } from './utils.js';
 
 // --- Panel rendering ---
 
@@ -160,7 +160,7 @@ function openEditor(idx) {
     if (existing) {
       state.cfg.prompts[idx] = { ...existing, name, text };
     } else {
-      state.cfg.prompts.push({ id: crypto.randomUUID(), name, text });
+      state.cfg.prompts.push({ id: randomUUID(), name, text });
     }
     save();
     closeEditor();

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -1,5 +1,5 @@
 import { state, send } from './state.js';
-import { esc, debounce, agentIcon, binName } from './utils.js';
+import { esc, debounce, agentIcon, binName, randomUUID } from './utils.js';
 import { openFolderPicker } from './folder-picker.js';
 
 // ── Category navigation ──
@@ -323,7 +323,7 @@ function openPresetMenu(anchorEl) {
     const presetId = item.dataset.preset;
     if (presetId === 'custom') {
       state.cfg.commands.push({
-        id: crypto.randomUUID(), label: '', icon: 'terminal', command: '',
+        id: randomUUID(), label: '', icon: 'terminal', command: '',
         enabled: true, defaultPath: '', isAgent: false, canResume: false,
         resumeCommand: null, sessionIdPattern: null,
         telemetryEnabled: false, telemetryStatus: null, env: {}, userAdded: true,
@@ -331,7 +331,7 @@ function openPresetMenu(anchorEl) {
     } else {
       const p = presets.find(x => x.presetId === presetId);
       if (p) state.cfg.commands.push({
-        id: crypto.randomUUID(), presetId: p.presetId, label: p.name, icon: p.icon, command: p.command,
+        id: randomUUID(), presetId: p.presetId, label: p.name, icon: p.icon, command: p.command,
         enabled: true, defaultPath: '', isAgent: p.isAgent, canResume: p.canResume,
         resumeCommand: p.resumeCommand, sessionIdPattern: p.sessionIdPattern,
         outputMarker: p.outputMarker || null,
@@ -600,7 +600,7 @@ function saveConfig() {
     const presetId = card.querySelector('.agent-preset')?.value || null;
     const preset = presetId ? state.presets.find(p => p.presetId === presetId) : null;
     return {
-      id: existing.id || crypto.randomUUID(),
+      id: existing.id || randomUUID(),
       presetId,
       label: card.querySelector('.agent-name').value.trim() || 'Untitled',
       icon: existing.icon || preset?.icon || 'terminal',

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -17,6 +17,8 @@ function switchCategory(catId) {
   document.querySelectorAll('.settings-panel').forEach(p => p.classList.add('hidden'));
   const panel = document.getElementById(`settings-${catId}`);
   if (panel) panel.classList.remove('hidden');
+  const overlay = document.getElementById('settings-overlay');
+  if (overlay) overlay.scrollTop = 0;
 }
 
 document.getElementById('settings-nav').addEventListener('click', (e) => {

--- a/public/js/state.js
+++ b/public/js/state.js
@@ -14,5 +14,6 @@ export const state = {
 };
 
 export function send(msg) {
+  if (!state.ws || state.ws.readyState !== WebSocket.OPEN) return;
   state.ws.send(JSON.stringify(msg));
 }

--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -1,3 +1,13 @@
+export function randomUUID() {
+  if (typeof crypto?.randomUUID === 'function') return crypto.randomUUID();
+  const arr = new Uint8Array(16);
+  crypto.getRandomValues(arr);
+  arr[6] = (arr[6] & 0x0f) | 0x40;
+  arr[8] = (arr[8] & 0x3f) | 0x80;
+  const h = [...arr].map(b => b.toString(16).padStart(2, '0'));
+  return `${h.slice(0,4).join('')}-${h.slice(4,6).join('')}-${h.slice(6,8).join('')}-${h.slice(8,10).join('')}-${h.slice(10,16).join('')}`;
+}
+
 export function binName(command) {
   const m = command.match(/^(['"])(.*?)\1/);
   const exec = m ? m[2] : command;


### PR DESCRIPTION
## Summary

Three bugs fixed, all found while running clideck from source on a headless Linux server accessed over Tailscale (plain HTTP).

### Bug 1 — `crypto.randomUUID()` not available on HTTP (Firefox)

Firefox restricts `crypto.randomUUID()` to secure contexts (HTTPS). On plain HTTP, it throws `crypto.randomUUID is not a function`, silently aborting any handler that creates an ID — project creation, adding agents, saving prompts, installing agents.

**Fix:** Add a `randomUUID()` polyfill to `utils.js` that delegates to `crypto.randomUUID()` when available and falls back to `crypto.getRandomValues()` (available in all contexts in all browsers). Replace all 8 call sites across `app.js`, `creator.js`, `settings.js`, and `prompts.js`.

### Bug 2 — Settings category switch doesn't scroll to top

After scrolling within a settings category panel (e.g. General), clicking a different category (e.g. CLI Agents) hides the old panel and shows the new one, but `settings-overlay`'s scroll position stays put. The new panel's content starts at `scrollTop = 0` but the viewport is scrolled past it, making the content area appear blank.

**Fix:** Reset `settings-overlay.scrollTop = 0` at the end of `switchCategory()`.

### Bug 3 — `send()` throws during WebSocket reconnect window

`send()` calls `state.ws.send()` unconditionally. The reconnect handler schedules `connect()` 1s after close, leaving a window where `readyState !== OPEN`. Any UI action that calls `send()` during this window throws `InvalidStateError`, silently aborting the caller.

**Fix:** Guard `send()` with a `readyState === WebSocket.OPEN` check and return early instead of throwing.

### Bug 4 — xdg-open crashes on headless Linux

On Linux servers without a display, `xdg-open` tries every browser it can find and fails with a wall of `Permission denied` lines. The raw error was forwarded to the client as-is.

**Fix:** Check `DISPLAY` and `WAYLAND_DISPLAY` before attempting `xdg-open`. When neither is set, skip the exec and instead send a structured `{ headless: true, path }` response. The client copies the path to clipboard and shows a confirmation toast.

## Test plan

- [ ] Firefox on HTTP: create a project, add an agent, save a prompt — all should work without errors
- [ ] Scroll down in General settings, click CLI Agents — content area should jump to top of new panel
- [ ] Kill/restart the server while UI is open, then interact within 1s — handlers should not abort silently
- [ ] Click "Open project folder" on a headless Linux server — path should be copied to clipboard with a toast