### PR TITLE
Fix invalid StopFailure hook event breaking Claude Code settings.json

### DIFF
--- a/handlers.js
+++ b/handlers.js
@@ -261,7 +261,6 @@ function detectTelemetryConfig(c) {
           repairAllowed = repairAllowed || hasAnyExistingHook(hooks, 'claude-hook.js');
           detected = hasExistingHook(hooks.UserPromptSubmit, 'claude-hook.js', 'start')
                   && hasExistingHook(hooks.Stop, 'claude-hook.js', 'stop')
-                  && hasExistingHook(hooks.StopFailure, 'claude-hook.js', 'stop')
                   && hasExistingHook(hooks.SessionStart, 'claude-hook.js', 'session-start')
                   && hasExistingHook(hooks.SessionEnd, 'claude-hook.js', 'session-end')
                   && hasExistingHook(hooks.PreToolUse, 'claude-hook.js', 'menu')
@@ -760,12 +759,17 @@ function applyTelemetryConfig(preset, cmd = null) {
         try { settings = JSON.parse(readFileSync(configPath, 'utf8')); } catch {}
       }
       const hooks = settings.hooks || {};
+      // StopFailure isn't a real Claude Code hook event; a previous version of this
+      // installer wrote it, which makes Claude Code reject the whole settings.json.
+      // Scrub it from anyone who already has it, on every run.
+      const hadStopFailure = 'StopFailure' in hooks;
+      delete hooks.StopFailure;
       const hookCmd = (route) => `"${process.execPath.replace(/\\/g, '/')}" "${join(__dirname, 'bin', 'claude-hook.js').replace(/\\/g, '/')}" ${port} ${route}`;
       const clideckHook = (route) => ({ hooks: [{ type: 'command', command: hookCmd(route) }] });
       const hasClideck = (arr, path) => arr?.some(h => h.hooks?.some(x => x.command === hookCmd(path)));
-      if (hasClideck(hooks.UserPromptSubmit, 'start')
+      if (!hadStopFailure
+          && hasClideck(hooks.UserPromptSubmit, 'start')
           && hasClideck(hooks.Stop, 'stop')
-          && hasClideck(hooks.StopFailure, 'stop')
           && hasClideck(hooks.SessionStart, 'session-start')
           && hasClideck(hooks.SessionEnd, 'session-end')
           && hasClideck(hooks.PreToolUse, 'menu')
@@ -775,14 +779,12 @@ function applyTelemetryConfig(preset, cmd = null) {
       const stripOld = (arr) => (arr || []).filter(h => !h.hooks?.some(x => x.url?.includes('/hook/claude/') || x.command?.includes('claude-hook.js')));
       hooks.UserPromptSubmit = stripOld(hooks.UserPromptSubmit);
       hooks.Stop = stripOld(hooks.Stop);
-      hooks.StopFailure = stripOld(hooks.StopFailure);
       hooks.SessionStart = stripOld(hooks.SessionStart);
       hooks.SessionEnd = stripOld(hooks.SessionEnd);
       hooks.PreToolUse = stripOld(hooks.PreToolUse);
       hooks.Notification = stripOld(hooks.Notification);
       if (!hasClideck(hooks.UserPromptSubmit, 'start')) hooks.UserPromptSubmit = [...(hooks.UserPromptSubmit || []), clideckHook('start')];
       if (!hasClideck(hooks.Stop, 'stop')) hooks.Stop = [...(hooks.Stop || []), clideckHook('stop')];
-      if (!hasClideck(hooks.StopFailure, 'stop')) hooks.StopFailure = [...(hooks.StopFailure || []), clideckHook('stop')];
       if (!hasClideck(hooks.SessionStart, 'session-start')) hooks.SessionStart = [...(hooks.SessionStart || []), clideckHook('session-start')];
       if (!hasClideck(hooks.SessionEnd, 'session-end')) hooks.SessionEnd = [...(hooks.SessionEnd || []), clideckHook('session-end')];
       if (!hasClideck(hooks.Notification, 'idle')) hooks.Notification = [...(hooks.Notification || []), { matcher: 'idle_prompt', ...clideckHook('idle') }];
@@ -883,7 +885,7 @@ function removeTelemetryConfig(preset, cmd = null) {
       let settings = {};
       try { settings = JSON.parse(readFileSync(configPath, 'utf8')); } catch {}
       if (!settings.hooks) return { success: true, message: 'No hooks to remove' };
-      for (const event of ['UserPromptSubmit', 'Stop', 'StopFailure', 'SessionStart', 'SessionEnd', 'Notification', 'PreToolUse']) {
+      for (const event of ['UserPromptSubmit', 'Stop', 'SessionStart', 'SessionEnd', 'Notification', 'PreToolUse']) {
         const arr = settings.hooks[event];
         if (!arr) continue;
         settings.hooks[event] = arr.filter(h => !h.hooks?.some(x => x.url?.includes('/hook/claude/') || x.command?.includes('claude-hook.js')));
@@ -943,4 +945,4 @@ function removeTelemetryConfig(preset, cmd = null) {
 
 function getConfig() { return cfg; }
 
-module.exports = { onConnection, getConfig };
+module.exports = { onConnection, getConfig, applyTelemetryConfig, removeTelemetryConfig };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build:css": "tailwindcss -i src/input.css -o public/tailwind.css --minify",
     "prepublishOnly": "npm run build:css",
     "smoke:providers": "node tests/providers/run.js",
-    "smoke:menu": "node tests/providers/menu-detection.test.js"
+    "smoke:menu": "node tests/providers/menu-detection.test.js",
+    "smoke:telemetry-config": "node tests/providers/telemetry-config.test.js"
   },
   "keywords": [
     "terminal",

--- a/tests/providers/telemetry-config.test.js
+++ b/tests/providers/telemetry-config.test.js
@@ -1,0 +1,80 @@
+// Regression test for the claude-code settings.json hook writer: it must
+// never write a 'StopFailure' key. That event name doesn't exist in Claude
+// Code's hook schema, and writing it makes Claude Code's settings.json parser
+// reject the *entire* file ("Invalid key in record"), silently breaking
+// hooks, hints, and permissions.
+//
+//   node tests/providers/telemetry-config.test.js
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { applyTelemetryConfig } = require('../../handlers');
+
+const preset = { presetId: 'claude-code' };
+
+function withTmpConfigDir(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'clideck-telemetry-test-'));
+  try {
+    return fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function readSettings(dir) {
+  return JSON.parse(fs.readFileSync(path.join(dir, 'settings.json'), 'utf8'));
+}
+
+let failed = 0;
+
+function check(name, fn) {
+  try {
+    fn();
+    console.log(`  \x1b[32mPASS\x1b[0m  ${name}`);
+  } catch (e) {
+    failed++;
+    console.log(`  \x1b[31mFAIL\x1b[0m  ${name}  ${e.message}`);
+  }
+}
+
+check('applyTelemetryConfig never writes a StopFailure key', () => {
+  withTmpConfigDir((dir) => {
+    const cmd = { env: { CLAUDE_CONFIG_DIR: dir } };
+    const result = applyTelemetryConfig(preset, cmd);
+    assert(result.success, `expected success, got: ${result.message}`);
+    const settings = readSettings(dir);
+    assert(!('StopFailure' in settings.hooks), 'StopFailure key should not be written');
+    assert(Array.isArray(settings.hooks.Stop) && settings.hooks.Stop.length > 0, 'Stop hook should be installed');
+  });
+});
+
+check('applyTelemetryConfig is idempotent (second run reports already configured)', () => {
+  withTmpConfigDir((dir) => {
+    const cmd = { env: { CLAUDE_CONFIG_DIR: dir } };
+    applyTelemetryConfig(preset, cmd);
+    const second = applyTelemetryConfig(preset, cmd);
+    assert(second.success, `expected success, got: ${second.message}`);
+    assert.strictEqual(second.message, 'Already configured');
+  });
+});
+
+check('a pre-existing stray StopFailure key is stripped by a re-run', () => {
+  withTmpConfigDir((dir) => {
+    const configPath = path.join(dir, 'settings.json');
+    fs.writeFileSync(configPath, JSON.stringify({
+      hooks: {
+        StopFailure: [{ hooks: [{ type: 'command', command: 'node /some/old/claude-hook.js 1234 stop' }] }],
+      },
+    }));
+    const cmd = { env: { CLAUDE_CONFIG_DIR: dir } };
+    const result = applyTelemetryConfig(preset, cmd);
+    assert(result.success, `expected success, got: ${result.message}`);
+    const settings = readSettings(dir);
+    assert(!('StopFailure' in settings.hooks), 'stray StopFailure key should have been stripped');
+  });
+});
+
+console.log('');
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
## Summary
- `StopFailure` isn't a valid Claude Code hook event, so `applyTelemetryConfig()` writing it to `~/.claude/settings.json` made Claude Code's parser reject the entire file ("Invalid key in record"), breaking hooks, hints, and permissions for the user.
- Removed the `StopFailure` branch from `applyTelemetryConfig`, the matching check in `detectTelemetryConfig`, and the entry in `removeTelemetryConfig`'s cleanup list — the existing `Stop` hook already covers this case.
- `applyTelemetryConfig` now proactively strips any existing `hooks.StopFailure` key on every run (it runs automatically each session), so users who are already broken by this bug get self-healed instead of staying broken forever.

Fixes #30

## Test plan
- [x] Added `tests/providers/telemetry-config.test.js` (`npm run smoke:telemetry-config`): asserts `applyTelemetryConfig` for preset `claude-code` never writes a `StopFailure` key, is idempotent, and strips a pre-existing stray `StopFailure` key on the next run.
- [x] Existing `npm run smoke:menu` still passes.
- [x] `node -c handlers.js` — no syntax errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)