### PR TITLE
fix: ignore OSC 52 clipboard writes during terminal replay

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -114,7 +114,7 @@ function connect() {
       case 'output': {
         const entry = state.terms.get(msg.id);
         if (msg.replay && reconnectReplaySkip?.has(msg.id) && entry) break;
-        if (entry && !entry.queue(msg.data)) entry.term.write(msg.data);
+        if (entry && !entry.queue(msg.data, !!msg.replay)) entry.writeChunk(msg.data, !!msg.replay);
         updatePreview(msg.id);
         markUnread(msg.id);
         break;
@@ -148,7 +148,7 @@ function connect() {
         const entry = state.terms.get(msg.id);
         if (msg.replay && reconnectReplaySkip?.has(msg.id) && entry) break;
         const historyText = normalizeTerminalHistoryText(msg.text);
-        if (entry && !entry.queue(historyText)) entry.term.write(historyText);
+        if (entry && !entry.queue(historyText, !!msg.replay)) entry.writeChunk(historyText, !!msg.replay);
         updatePreview(msg.id);
         break;
       }

--- a/public/js/hotkeys.js
+++ b/public/js/hotkeys.js
@@ -100,9 +100,11 @@ function decodeOsc52(data) {
   }
 }
 
-function attachClipboardOscHandler(term) {
+function attachClipboardOscHandler(term, isReplaying) {
   if (!term.parser?.registerOscHandler) return;
   term.parser.registerOscHandler(52, (data) => {
+    // Replayed terminal history must not repeat clipboard side effects.
+    if (isReplaying?.()) return true;
     const text = decodeOsc52(data);
     if (!text || !navigator.clipboard?.writeText) return false;
     return navigator.clipboard.writeText(text).then(() => true, () => false);
@@ -112,8 +114,8 @@ function attachClipboardOscHandler(term) {
 // Attach to an xterm terminal instance — xterm's hidden textarea is an input,
 // so we bypass the isInput check and dispatch directly.
 // Prompt autocomplete (// trigger) runs first, then hotkey dispatch.
-export function attachToTerminal(term, presetId) {
-  attachClipboardOscHandler(term);
+export function attachToTerminal(term, presetId, isReplaying) {
+  attachClipboardOscHandler(term, isReplaying);
   term.attachCustomKeyEventHandler((e) => {
     if (e.type === 'keydown'
       && e.ctrlKey

--- a/public/js/terminals.js
+++ b/public/js/terminals.js
@@ -726,7 +726,13 @@ export function addTerminal(id, name, themeId, commandId, projectId, muted, last
   const refreshJumpLatest = () => updateJumpLatestButton(id, term, jumpLatestBtn);
   term.onScroll(refreshJumpLatest);
   term.onWriteParsed(refreshJumpLatest);
-  attachToTerminal(term, presetId);
+  let replayWrites = 0;
+  const writeChunk = (data, replay = false) => {
+    if (!replay) { term.write(data); return; }
+    replayWrites += 1;
+    term.write(data, () => { replayWrites -= 1; });
+  };
+  attachToTerminal(term, presetId, () => replayWrites > 0);
   const onContextMenu = (e) => {
     if (e.shiftKey) return;
     e.preventDefault();
@@ -751,7 +757,7 @@ export function addTerminal(id, name, themeId, commandId, projectId, muted, last
       fitted = true;
       fit.fit();
       send({ type: 'resize', id, cols: term.cols, rows: term.rows });
-      for (const chunk of pending) term.write(chunk);
+      for (const chunk of pending) writeChunk(chunk.data, chunk.replay);
       pending = null;
       updatePreview(id);
       refreshJumpLatest();
@@ -774,14 +780,14 @@ export function addTerminal(id, name, themeId, commandId, projectId, muted, last
         return;
       }
       fitted = true;
-      for (const chunk of pending) term.write(chunk);
+      for (const chunk of pending) writeChunk(chunk.data, chunk.replay);
       pending = null;
       updatePreview(id);
       refreshJumpLatest();
     }
   }, 500);
   const cancelFitRaf = () => { if (fitRaf) { cancelAnimationFrame(fitRaf); fitRaf = 0; } };
-  state.terms.set(id, { term, fit, el, ro, cancelFitRaf, onContextMenu, inputLength: 0, inputHasText: false, scrolledUp: false, themeId, commandId, presetId: presetId || null, projectId: projectId || null, muted: !!muted, working: false, workStartedAt: null, stopBounce, queue: (data) => { if (!fitted) { pending.push(data); return true; } return false; }, lastActivityAt: Date.now(), unread: false, lastPreviewText: lastPreview || '', searchText: '' });
+  state.terms.set(id, { term, fit, el, ro, cancelFitRaf, onContextMenu, inputLength: 0, inputHasText: false, scrolledUp: false, themeId, commandId, presetId: presetId || null, projectId: projectId || null, muted: !!muted, working: false, workStartedAt: null, stopBounce, queue: (data, replay = false) => { if (!fitted) { pending.push({ data, replay }); return true; } return false; }, writeChunk, lastActivityAt: Date.now(), unread: false, lastPreviewText: lastPreview || '', searchText: '' });
   if (working) setStatus(id, true);
   else renderSessionStatus(state.terms.get(id), statusEl, false); // idle sessions get the zᶻZ icon now, not a blank slot until their first transition
   refreshTerminalInputActions();


### PR DESCRIPTION
## What changed

Tracks when xterm is parsing replayed terminal output and ignores OSC 52 clipboard writes during that window. Live OSC 52 copying is unchanged.

## Why

CliDeck replays raw PTY history when a browser terminal is rebuilt. OSC 52 sequences in that history are parsed again, which can overwrite the user's current clipboard. On Android, each replayed copy can also surface a system clipboard notification.

## How to verify

1. Emit an OSC 52 sequence and confirm the live value reaches the clipboard.
2. Replace the clipboard with a sentinel value and reload CliDeck.
3. Confirm terminal history is restored and the sentinel remains unchanged.

Verified with a disposable Chromium instance.

## Out of scope

No server, protocol, mobile UI, or dependency changes.
