### PR TITLE
feat(plugins): add Git Diff plugin

### DIFF
--- a/plugins/git-diff/UPSTREAM.md
+++ b/plugins/git-diff/UPSTREAM.md
@@ -1,0 +1,101 @@
+# Suggestion for CliDeck core: expose the session process id to plugins
+
+## What this asks for
+
+Add the session's pty process id to the two session projections the plugin API hands out, in
+`plugin-loader.js`:
+
+```js
+// getSession(id), currently line 219
+return { id, name: s.name, cwd: s.cwd, pid: s.pty?.pid || 0, commandId: s.commandId,
+         presetId: s.presetId || 'shell', themeId: s.themeId, projectId: s.projectId,
+         working: state.startsWith('1:') };
+
+// getSessions(), currently line 225
+return [...sessions].map(([id, s]) => ({
+  id, name: s.name, cwd: s.cwd, pid: s.pty?.pid || 0, commandId: s.commandId,
+  presetId: s.presetId || 'shell', themeId: s.themeId, projectId: s.projectId,
+  working: (sessionStatus.get(id) || '').startsWith('1:'),
+}));
+```
+
+Two lines. No behaviour change for existing plugins, and nothing new is computed: `pty.pid` is
+already on the session object created in `sessions.js:119`.
+
+## Why a plugin needs it
+
+`cwd` in the projection is the folder a session was **spawned** in, fixed at creation
+(`sessions.js:205`, `:242`, `:287`). It is not where the session is now. An agent that runs
+`cd` into a subdirectory, or into a git worktree, leaves `cwd` pointing at the original folder,
+and a plugin has no way to notice.
+
+That gap is visible in the Git Diff plugin. A session started in a repository's main checkout,
+whose agent then moved into a linked worktree, would show the diff of the main checkout: usually
+empty, and confusing, because the terminal clearly shows work happening somewhere else.
+
+With a pid, a plugin can read the real working directory. On Linux that is
+`readlink /proc/<pid>/cwd`, which is cheap and needs no privileges for a process owned by the
+same user. macOS has no `/proc`, so a plugin there would fall back to the spawn folder or shell
+out to `lsof`. The point is that the pid is the only missing piece; everything after it is the
+plugin's problem.
+
+## Other uses this would unlock
+
+- Resource display: read `/proc/<pid>/stat` or run `ps` for CPU and memory per session, so a
+  plugin could show which agent is actually busy.
+- Liveness beyond the status heuristic: `process.kill(pid, 0)` answers whether the process is
+  still there, independent of the output-based working/idle detection in `plugin-loader.js`.
+- Process inspection: which command a session is really running now, from
+  `/proc/<pid>/comm` or `cmdline`, rather than the configured `commandId`.
+- Targeted signals: a plugin could send `SIGINT` to a specific session rather than writing
+  `\x03` into the terminal and hoping the foreground process takes it.
+
+## Why not just reach for it another way
+
+A plugin can already get the pid without any core change, and that is the argument for adding
+it. Because `sessions.js` is loaded in the same process before plugins initialise, a plugin can
+scan `require.cache` for it and call `getSessions()` to reach the live session map, `pty`
+object included:
+
+```js
+for (const mod of Object.values(require.cache)) {
+  if (mod.filename.endsWith('/sessions.js') && typeof mod.exports.getSessions === 'function') {
+    const pid = mod.exports.getSessions().get(sessionId)?.pty?.pid;
+  }
+}
+```
+
+That works today. The Git Diff plugin deliberately does **not** do it, and the feature stays
+switched off instead, because the technique is worth discouraging: it bypasses the projection
+the API exists to provide, it hands a plugin the whole `pty` object rather than one field, and
+it breaks silently on any rename, bundling change or move to ESM. A plugin author who wants
+this badly enough will reach for it anyway. Exposing one integer through the API removes the
+incentive and keeps the boundary meaningful.
+
+## Security note
+
+The pid is only useful to code already running inside the CliDeck server process, which can
+call `process.kill` or read `/proc` regardless. Plugins are trusted code, installed
+deliberately from disk, and already receive `inputToSession`, `createSession` and
+`closeSession`. Adding a pid grants no capability that is not already reachable.
+
+## Compatibility
+
+Additive. Existing plugins ignore the extra field. `0` is a reasonable value for a session with
+no live pty, so a plugin can treat falsy as "unavailable" without special cases, which is what
+Git Diff does:
+
+```js
+function ptyPid(session) {
+  return session && Number.isInteger(session.pid) && session.pid > 0 ? session.pid : 0;
+}
+```
+
+Today that always returns `0`, the live folder lookup is skipped, and the plugin uses the spawn
+folder. If this change lands, the feature starts working with no edit to the plugin.
+
+## Status
+
+Proposed, not applied. The change is not made locally because patching `plugin-loader.js` in a
+fork means carrying a diff against a file upstream also edits. CONTRIBUTING.md points feature
+ideas at a **Show & Tell** Discussion, so that is where this goes, alongside the plugin itself.

--- a/plugins/git-diff/clideck-plugin.json
+++ b/plugins/git-diff/clideck-plugin.json
@@ -1,0 +1,126 @@
+{
+  "id": "git-diff",
+  "name": "Git Diff",
+  "version": "1.0.0",
+  "author": "CliDeck",
+  "description": "View the git diff of a session's working folder without leaving CliDeck",
+  "icon": "<svg class=\"w-4 h-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"1.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><circle cx=\"6\" cy=\"6\" r=\"2.5\"/><circle cx=\"6\" cy=\"18\" r=\"2.5\"/><circle cx=\"18\" cy=\"9\" r=\"2.5\"/><path d=\"M6 8.5v7\"/><path d=\"M18 11.5c0 3.5-3 4.5-6 4.5\"/><path d=\"M15.5 9H8.5\"/></svg>",
+  "install": "npm",
+  "settings": [
+    {
+      "key": "enabled",
+      "label": "Enabled",
+      "type": "toggle",
+      "default": true
+    },
+    {
+      "key": "defaultScope",
+      "label": "Default Scope",
+      "type": "select",
+      "default": "uncommitted",
+      "options": [
+        {
+          "value": "uncommitted",
+          "label": "Uncommitted changes"
+        },
+        {
+          "value": "base",
+          "label": "Everything since base branch"
+        }
+      ],
+      "description": "Which scope the diff opens on"
+    },
+    {
+      "key": "defaultLayout",
+      "label": "Default Layout",
+      "type": "select",
+      "default": "side-by-side",
+      "options": [
+        {
+          "value": "side-by-side",
+          "label": "Split"
+        },
+        {
+          "value": "line-by-line",
+          "label": "Unified"
+        }
+      ]
+    },
+    {
+      "key": "baseBranch",
+      "label": "Base Branch",
+      "type": "text",
+      "default": "",
+      "placeholder": "auto-detect",
+      "description": "Branch to compare against in base scope. Empty means detect origin/HEAD, then main, then master"
+    },
+    {
+      "key": "syntaxHighlight",
+      "label": "Syntax Highlighting",
+      "type": "toggle",
+      "default": true,
+      "description": "Colour code in the diff using highlight.js"
+    },
+    {
+      "key": "highlightTheme",
+      "label": "Highlight Theme",
+      "type": "select",
+      "default": "github-dark",
+      "options": [
+        {
+          "value": "github-dark",
+          "label": "GitHub Dark"
+        },
+        {
+          "value": "github-dark-dimmed",
+          "label": "GitHub Dark Dimmed"
+        },
+        {
+          "value": "atom-one-dark",
+          "label": "Atom One Dark"
+        },
+        {
+          "value": "monokai",
+          "label": "Monokai"
+        },
+        {
+          "value": "nord",
+          "label": "Nord"
+        }
+      ]
+    },
+    {
+      "key": "contextLines",
+      "label": "Context Lines",
+      "type": "number",
+      "default": 3,
+      "min": 0,
+      "max": 20,
+      "description": "Unchanged lines shown around each change"
+    },
+    {
+      "key": "pollSeconds",
+      "label": "Auto-refresh Seconds",
+      "type": "number",
+      "default": 3,
+      "min": 0,
+      "max": 60,
+      "description": "How often to re-run git while the diff is open. 0 disables auto-refresh"
+    },
+    {
+      "key": "maxChanges",
+      "label": "Max Changed Lines",
+      "type": "number",
+      "default": 20000,
+      "min": 100,
+      "description": "Diffs larger than this show a placeholder instead of rendering"
+    },
+    {
+      "key": "hotkey",
+      "label": "Open Key",
+      "type": "text",
+      "default": "F9",
+      "description": "Key to open and close the diff (e.g. F9, Ctrl+Shift+D)"
+    }
+  ]
+}

--- a/plugins/git-diff/client.js
+++ b/plugins/git-diff/client.js
@@ -1,0 +1,530 @@
+// Git Diff client — toolbar button plus a diff overlay for the active session's folder.
+// The server does the git work and the diff2html rendering; this file frames it and handles state.
+
+const ICON = '<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="6" r="2.5"/><circle cx="6" cy="18" r="2.5"/><circle cx="18" cy="9" r="2.5"/><path d="M6 8.5v7"/><path d="M18 11.5c0 3.5-3 4.5-6 4.5"/><path d="M15.5 9H8.5"/></svg>';
+const EXPAND_ICON = '<svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M6 2H2v4M10 14h4v-4M14 6V2h-4M2 10v4h4"/></svg>';
+const COMPRESS_ICON = '<svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M2 6h4V2M14 10h-4v4M10 2v4h4M6 14v-4H2"/></svg>';
+const COLLAPSE_THRESHOLD = 10; // more files than this and they start collapsed
+const TAG = Math.random().toString(36).slice(2, 8); // distinguishes this tab's requests
+
+let api = null;
+let settings = {};
+let btnEl = null;
+let currentHotkey = null;
+let stylesRequested = false;
+let appliedTheme = '';
+
+let overlay = null;
+let el = {};
+let sessionId = null;
+let scope = 'uncommitted';
+let layout = 'side-by-side';
+let maximised = false;                  // remembered across opens while the tab stays open
+let folder = '';                        // folder being diffed; '' means the session's own folder
+const folderBySession = new Map();      // remembers the choice while the tab stays open
+let pendingRequest = null;
+let pendingPatchRequest = null;
+let requestSeq = 0;
+let pollTimer = null;
+let collapsed = new Set();
+let collapseKey = '';
+let lastReply = null;
+
+// --- setup ---
+
+export function init(pluginApi) {
+  api = pluginApi;
+
+  api.onMessage('settings', (msg) => {
+    const previous = settings;
+    settings = msg || {};
+    if (btnEl) btnEl.style.display = settings.enabled === false ? 'none' : '';
+    if (settings.enabled === false) close();
+    bindHotkey(settings.hotkey || 'F9');
+    // Highlighting is applied server-side, so a theme or toggle change needs fresh CSS and a
+    // re-render of the diff itself.
+    const highlightChanged = stylesRequested
+      && (settings.highlightTheme !== previous.highlightTheme || settings.syntaxHighlight !== previous.syntaxHighlight);
+    if (highlightChanged) api.send('getStyles');
+    if (overlay && !overlay.hidden) {
+      startPolling();
+      if (highlightChanged) { lastReply = null; request('diff'); }
+    }
+  });
+  api.onMessage('styles', (msg) => injectStyles(msg || {}));
+  api.onMessage('diff', onDiffReply);
+  api.onMessage('patch', onPatchReply);
+
+  api.send('getSettings');
+
+  btnEl = api.addToolbarButton({ title: 'Git Diff', icon: ICON, onClick: toggle });
+}
+
+function bindHotkey(hotkey) {
+  if (hotkey === currentHotkey) return;
+  const previous = currentHotkey;
+  if (previous) api.unregisterHotkey(previous);
+  if (api.registerHotkey(hotkey, toggle)) {
+    currentHotkey = hotkey;
+    return;
+  }
+  if (previous && api.registerHotkey(previous, toggle)) {
+    api.toast(`Hotkey "${hotkey}" is taken, keeping "${previous}"`, { type: 'warn' });
+  } else {
+    currentHotkey = null;
+    api.toast(`Hotkey "${hotkey}" is unavailable`, { type: 'warn' });
+  }
+}
+
+// diff2html's stylesheet and the highlight.js theme both arrive over the WebSocket, so there
+// is no copy of either on disk to go stale.
+function injectStyles(msg) {
+  if (msg.css) setStyleBlock('gd-d2h-styles', msg.css);
+  // Replaced rather than skipped, because the theme can change in settings.
+  if (typeof msg.hljsCss === 'string') {
+    setStyleBlock('gd-hljs-styles', msg.hljsCss);
+    appliedTheme = msg.theme || '';
+  }
+}
+
+function setStyleBlock(id, css) {
+  let style = document.getElementById(id);
+  if (!style) {
+    style = document.createElement('style');
+    style.id = id;
+    document.head.appendChild(style);
+  }
+  if (style.textContent !== css) style.textContent = css;
+}
+
+function ensureChrome() {
+  if (!document.getElementById('gd-chrome-styles')) {
+    const link = document.createElement('link');
+    link.id = 'gd-chrome-styles';
+    link.rel = 'stylesheet';
+    // resolveFile() maps this straight into the plugin's public/ folder, so no "public" segment.
+    link.href = '/plugins/git-diff/git-diff.css';
+    document.head.appendChild(link);
+  }
+  if (!stylesRequested) {
+    stylesRequested = true;
+    api.send('getStyles');
+  }
+  if (overlay) return;
+
+  overlay = document.createElement('div');
+  overlay.className = 'gd-overlay';
+  overlay.hidden = true;
+  overlay.innerHTML = `
+    <div class="gd-panel">
+      <div class="gd-head">
+        <div class="gd-head-row">
+          <span class="gd-icon">${ICON}</span>
+          <span class="gd-session"></span>
+          <span class="gd-branch"></span>
+          <select class="gd-folder" title="Folder to diff"></select>
+          <button class="gd-btn gd-icon-btn gd-full" title="Maximise">${EXPAND_ICON}</button>
+          <button class="gd-btn gd-icon-btn gd-close" title="Close (Esc)">&#10005;</button>
+        </div>
+        <div class="gd-head-row gd-controls">
+          <div class="gd-seg" data-group="scope">
+            <button type="button" data-value="uncommitted">Uncommitted</button>
+            <button type="button" data-value="base">vs base</button>
+          </div>
+          <div class="gd-seg" data-group="layout">
+            <button type="button" data-value="side-by-side">Split</button>
+            <button type="button" data-value="line-by-line">Unified</button>
+          </div>
+          <span class="gd-summary"></span>
+          <span class="gd-spacer"></span>
+          <button class="gd-btn gd-files" type="button">Hide files</button>
+          <button class="gd-btn gd-collapse" type="button">Collapse all</button>
+          <button class="gd-btn gd-copy" type="button">Copy patch</button>
+          <button class="gd-btn gd-refresh" type="button">Refresh</button>
+        </div>
+      </div>
+      <div class="gd-note" hidden></div>
+      <div class="gd-body"></div>
+    </div>`;
+  document.body.appendChild(overlay);
+
+  el = {
+    session: overlay.querySelector('.gd-session'),
+    branch: overlay.querySelector('.gd-branch'),
+    folder: overlay.querySelector('.gd-folder'),
+    summary: overlay.querySelector('.gd-summary'),
+    note: overlay.querySelector('.gd-note'),
+    body: overlay.querySelector('.gd-body'),
+    scope: overlay.querySelector('.gd-seg[data-group="scope"]'),
+    layout: overlay.querySelector('.gd-seg[data-group="layout"]'),
+    full: overlay.querySelector('.gd-full'),
+    files: overlay.querySelector('.gd-files'),
+    collapse: overlay.querySelector('.gd-collapse'),
+    copy: overlay.querySelector('.gd-copy'),
+    refresh: overlay.querySelector('.gd-refresh'),
+  };
+
+  overlay.addEventListener('mousedown', (e) => { if (e.target === overlay) close(); });
+  overlay.querySelector('.gd-close').addEventListener('click', close);
+  el.full.addEventListener('click', toggleMaximised);
+  el.refresh.addEventListener('click', () => request('diff'));
+  el.copy.addEventListener('click', copyPatch);
+  el.files.addEventListener('click', toggleFileList);
+  el.collapse.addEventListener('click', toggleCollapseAll);
+
+  el.folder.addEventListener('change', () => {
+    const value = el.folder.value;
+    if (value === '__browse__' || !value) {
+      el.folder.value = folder || '';   // resync; '' means no matching option
+      if (value === '__browse__') browseForFolder();
+      return;
+    }
+    setFolder(value);
+  });
+
+  el.scope.addEventListener('click', (e) => {
+    const value = e.target.closest('button')?.dataset.value;
+    if (!value || value === scope) return;
+    scope = value;
+    request('diff');
+  });
+  el.layout.addEventListener('click', (e) => {
+    const value = e.target.closest('button')?.dataset.value;
+    if (!value || value === layout) return;
+    layout = value;
+    request('render'); // served from the server's cache, no new git call
+  });
+
+  // Collapse a file by clicking its header, ignoring clicks on the links inside it.
+  el.body.addEventListener('click', (e) => {
+    const header = e.target.closest('.d2h-file-header');
+    if (!header || e.target.closest('a, .d2h-file-collapse')) return;
+    const wrapper = header.closest('.d2h-file-wrapper');
+    const path = wrapper?.querySelector('.d2h-file-name')?.textContent?.trim();
+    if (!wrapper || !path) return;
+    if (collapsed.has(path)) collapsed.delete(path);
+    else collapsed.add(path);
+    wrapper.classList.toggle('gd-collapsed', collapsed.has(path));
+    updateCollapseButton();
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && overlay && !overlay.hidden) { e.stopPropagation(); close(); }
+  }, true);
+}
+
+// --- maximise ---
+
+// Fills the browser window rather than using the Fullscreen API, so the browser's own
+// chrome stays put and toasts and the folder picker keep working normally.
+function toggleMaximised() {
+  setMaximised(!maximised);
+}
+
+function setMaximised(on) {
+  maximised = on;
+  overlay.classList.toggle('gd-max', on);
+  el.full.innerHTML = on ? COMPRESS_ICON : EXPAND_ICON;
+  el.full.title = on ? 'Restore size' : 'Maximise';
+}
+
+// --- open / close ---
+
+function toggle() {
+  if (overlay && !overlay.hidden) close();
+  else open();
+}
+
+function open() {
+  if (settings.enabled === false) return;
+  const active = api.getActiveSessionId();
+  if (!active) { api.toast('Select a session first', { type: 'warn' }); return; }
+
+  ensureChrome();
+  sessionId = active;
+  folder = folderBySession.get(active) || '';   // '' lets the server use the session folder
+  scope = settings.defaultScope === 'base' ? 'base' : 'uncommitted';
+  layout = settings.defaultLayout === 'line-by-line' ? 'line-by-line' : 'side-by-side';
+  collapsed = new Set();
+  collapseKey = '';
+  lastReply = null;
+  overlay.hidden = false;
+  el.session.textContent = '';
+  el.branch.textContent = '';
+  el.summary.textContent = '';
+  syncSegments();
+  setMaximised(maximised);
+  request('diff');
+  startPolling();
+}
+
+function close() {
+  stopPolling();
+  pendingRequest = null;
+  if (overlay) {
+    overlay.hidden = true;
+    el.body.innerHTML = '';
+  }
+}
+
+function startPolling() {
+  stopPolling();
+  const seconds = Number(settings.pollSeconds);
+  if (!Number.isFinite(seconds) || seconds <= 0) return;
+  pollTimer = setInterval(() => {
+    if (!overlay || overlay.hidden) return;
+    if (document.hidden) return;      // nobody is looking
+    if (pendingRequest) return;       // previous request still out
+    request('diff', { quiet: true });
+  }, seconds * 1000);
+}
+
+function stopPolling() {
+  if (pollTimer) clearInterval(pollTimer);
+  pollTimer = null;
+}
+
+// --- requests ---
+
+function request(kind, opts = {}) {
+  if (!sessionId) return;
+  pendingRequest = `${TAG}-${++requestSeq}`;
+  if (!opts.quiet) {
+    el.refresh.classList.add('gd-busy');
+    if (!lastReply) el.body.innerHTML = '<div class="gd-state">Running git…</div>';
+  }
+  api.send(kind, { requestId: pendingRequest, sessionId, scope, layout, folder });
+}
+
+// --- folder selection ---
+
+function setFolder(path) {
+  if (!path || path === folder) return;
+  folder = path;
+  folderBySession.set(sessionId, path);
+  collapseKey = '';   // different folder, so previous collapse state is meaningless
+  lastReply = null;
+  request('diff');
+}
+
+async function browseForFolder() {
+  const start = folder || lastReply?.cwd || '';
+  try {
+    // The app's own picker, same module instance the rest of the UI uses, so its
+    // directory-listing replies are routed for us.
+    const { openFolderPicker } = await import('/js/folder-picker.js');
+    openFolderPicker(start, (chosen) => { if (chosen) setFolder(chosen); });
+  } catch {
+    api.toast('Folder picker unavailable in this CliDeck version', { type: 'warn' });
+  }
+}
+
+function shortenPath(path) {
+  const home = lastReply?.home || '';
+  return home && path.startsWith(home) ? `~${path.slice(home.length)}` : path;
+}
+
+function optionLabel(choice, repoRoot) {
+  const path = shortenPath(choice.path);
+  if (choice.kind === 'live') return `${path}  (${choice.label || 'in use now'})`;
+  if (choice.kind === 'session') return `${path}  (session start folder)`;
+  if (choice.kind === 'worktree' || choice.kind === 'current-worktree') {
+    const here = choice.path === repoRoot ? ', current' : '';
+    return choice.label ? `${path}  (worktree: ${choice.label}${here})` : `${path}  (worktree${here})`;
+  }
+  return path;
+}
+
+function renderFolderSelect(msg) {
+  let choices = msg.folders || [];
+  // A server that predates the folder selector sends no choices. Fall back to the folder it
+  // did report so the control shows something real rather than looking broken.
+  if (!choices.length) {
+    const path = msg.folder || msg.repoRoot || msg.cwd || '';
+    if (path) choices = [{ path, label: 'Session folder', kind: 'session' }];
+  }
+  const selected = msg.folder || choices[0]?.path || '';
+  el.folder.innerHTML = choices.map((c) =>
+    `<option value="${escapeHtml(c.path)}"${c.path === selected ? ' selected' : ''}>${escapeHtml(optionLabel(c, msg.repoRoot))}</option>`
+  ).join('') + '<option value="__browse__">Choose another folder…</option>';
+  el.folder.value = selected;
+  el.folder.title = selected;
+  // Keep local state aligned with what the server actually used.
+  folder = selected;
+  if (sessionId && selected) folderBySession.set(sessionId, selected);
+}
+
+function onDiffReply(msg) {
+  if (!overlay || overlay.hidden) return;
+  if (msg.requestId !== pendingRequest) return; // stale or another tab's reply
+  pendingRequest = null;
+  el.refresh.classList.remove('gd-busy');
+
+  if (!msg.ok) { renderError(msg); return; }
+  lastReply = msg;
+  renderDiff(msg);
+}
+
+function copyPatch() {
+  if (!sessionId) return;
+  pendingPatchRequest = `${TAG}-patch-${++requestSeq}`;
+  api.send('getPatch', { requestId: pendingPatchRequest, sessionId });
+}
+
+async function onPatchReply(msg) {
+  if (msg.requestId !== pendingPatchRequest) return;
+  pendingPatchRequest = null;
+  if (!msg.patch) { api.toast('No patch to copy', { type: 'warn' }); return; }
+  try {
+    await navigator.clipboard.writeText(msg.patch);
+    api.toast(`Copied ${msg.patch.length.toLocaleString()} chars of patch`, { type: 'success' });
+  } catch {
+    api.toast('Clipboard access denied — allow it in browser site settings', { type: 'error' });
+  }
+}
+
+// --- rendering ---
+
+function syncSegments() {
+  for (const [group, value] of [[el.scope, scope], [el.layout, layout]]) {
+    for (const btn of group.querySelectorAll('button')) {
+      btn.classList.toggle('gd-on', btn.dataset.value === value);
+    }
+  }
+}
+
+function renderError(msg) {
+  const hints = {
+    'not-a-repo': 'This session\'s folder is not inside a git repository.',
+    'no-git': 'git was not found on PATH of the CliDeck server process.',
+    'no-session': 'That session is no longer running.',
+    timeout: 'git took longer than 15 seconds and was stopped.',
+  };
+  stopPolling();
+  el.summary.textContent = '';
+  el.note.hidden = true;
+  renderFolderSelect(msg);   // keep the selector usable, or a bad choice is a dead end
+  el.body.innerHTML = `<div class="gd-state gd-error">
+    <div class="gd-error-title">${escapeHtml(hints[msg.code] || 'git failed')}</div>
+    ${msg.message ? `<pre class="gd-error-detail">${escapeHtml(msg.message)}</pre>` : ''}
+  </div>`;
+}
+
+function renderDiff(msg) {
+  el.session.textContent = msg.sessionName || 'session';
+  el.branch.textContent = msg.branch || '';
+  renderFolderSelect(msg);
+
+  const baseButton = el.scope.querySelector('button[data-value="base"]');
+  if (baseButton) baseButton.textContent = msg.baseLabel && scope === 'base' ? `vs ${msg.baseLabel}` : 'vs base';
+  syncSegments();
+
+  const { files = 0, additions = 0, deletions = 0 } = msg.totals || {};
+  el.summary.innerHTML = files
+    ? `${files} file${files === 1 ? '' : 's'} <span class="gd-add">+${additions}</span> <span class="gd-del">−${deletions}</span>`
+    : '';
+
+  const notes = [];
+  if (msg.folderRejected) notes.push('That folder no longer exists, so the session folder is shown instead.');
+  if (msg.folder && msg.repoRoot && msg.folder !== msg.repoRoot) notes.push(`Showing the whole repository at ${msg.repoRoot}, which contains the selected folder.`);
+  if (msg.baseFallback) notes.push('No base branch found to compare against, showing uncommitted changes instead.');
+  else if (msg.baseIsHead && msg.scope === 'base') notes.push(`No commits ahead of ${msg.baseLabel}, so this shows the same uncommitted changes.`);
+  const oversized = (msg.files || []).filter((f) => f.oversizedBytes);
+  if (oversized.length) {
+    notes.push(`${oversized.length} untracked file${oversized.length === 1 ? '' : 's'} too large to render: ${oversized.map((f) => `${f.path} (${formatBytes(f.oversizedBytes)})`).join(', ')}`);
+  }
+  el.note.hidden = notes.length === 0;
+  el.note.textContent = notes.join(' ');
+
+  // Reset collapse state when the session or scope changes, not on every poll.
+  const key = `${msg.sessionId}|${msg.scope}`;
+  const freshView = key !== collapseKey;
+  if (freshView) {
+    collapseKey = key;
+    collapsed = new Set();
+  }
+
+  const scrollTop = el.body.scrollTop;
+  if (!files) {
+    el.body.innerHTML = '<div class="gd-state">No changes.</div>';
+  } else if (msg.tooBig) {
+    el.body.innerHTML = renderFileListOnly(msg);
+  } else {
+    el.body.innerHTML = msg.html || '';
+    // Collapse keys come from the rendered headings, not the server's paths: diff2html shows a
+    // rename as "src/{old.js → new.js}", which never matches the path in msg.files.
+    if (freshView && files > COLLAPSE_THRESHOLD) collapsed = new Set(renderedFileNames());
+    applyCollapsed();
+  }
+  el.body.scrollTop = scrollTop;
+  updateCollapseButton();
+  updateFileListButton();
+}
+
+// Used when the diff is too large to render: the file list still tells you what moved.
+function renderFileListOnly(msg) {
+  const rows = (msg.files || []).map((f) => `<li class="gd-big-row">
+      <span class="gd-big-path">${escapeHtml(f.isRename ? `${f.oldPath} → ${f.path}` : f.path)}</span>
+      <span class="gd-big-stats"><span class="gd-add">+${f.additions}</span> <span class="gd-del">−${f.deletions}</span></span>
+    </li>`).join('');
+  const total = (msg.totals.additions + msg.totals.deletions).toLocaleString();
+  return `<div class="gd-state gd-toobig">
+      <div class="gd-error-title">Diff too large to render</div>
+      <p>${total} changed lines, over the ${Number(msg.maxChanges).toLocaleString()} line limit. Raise "Max Changed Lines" in the plugin settings, or use Copy patch.</p>
+    </div>
+    <ul class="gd-big-list">${rows}</ul>`;
+}
+
+function renderedFileNames() {
+  return [...el.body.querySelectorAll('.d2h-file-wrapper .d2h-file-name')]
+    .map((n) => n.textContent.trim())
+    .filter(Boolean);
+}
+
+function applyCollapsed() {
+  for (const wrapper of el.body.querySelectorAll('.d2h-file-wrapper')) {
+    const name = wrapper.querySelector('.d2h-file-name')?.textContent?.trim();
+    wrapper.classList.toggle('gd-collapsed', !!name && collapsed.has(name));
+  }
+}
+
+function toggleCollapseAll() {
+  const wrappers = [...el.body.querySelectorAll('.d2h-file-wrapper')];
+  if (!wrappers.length) return;
+  const expandAll = wrappers.every((w) => w.classList.contains('gd-collapsed'));
+  collapsed = expandAll ? new Set() : new Set(renderedFileNames());
+  applyCollapsed();
+  updateCollapseButton();
+}
+
+function updateCollapseButton() {
+  const wrappers = [...el.body.querySelectorAll('.d2h-file-wrapper')];
+  el.collapse.disabled = wrappers.length === 0;
+  const allCollapsed = wrappers.length > 0 && wrappers.every((w) => w.classList.contains('gd-collapsed'));
+  el.collapse.textContent = allCollapsed ? 'Expand all' : 'Collapse all';
+}
+
+// diff2html's own hide/show links need the diff2html-ui bundle, which is not loaded, so the
+// header button drives the file list instead and those links stay hidden by our CSS.
+function toggleFileList() {
+  const list = el.body.querySelector('.d2h-file-list-wrapper');
+  if (!list) return;
+  list.classList.toggle('gd-hidden');
+  updateFileListButton();
+}
+
+function updateFileListButton() {
+  const list = el.body.querySelector('.d2h-file-list-wrapper');
+  el.files.disabled = !list;
+  el.files.textContent = list && list.classList.contains('gd-hidden') ? 'Show files' : 'Hide files';
+}
+
+function formatBytes(bytes) {
+  if (bytes >= 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+  if (bytes >= 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${bytes} B`;
+}
+
+function escapeHtml(value) {
+  return String(value ?? '').replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+}

--- a/plugins/git-diff/index.js
+++ b/plugins/git-diff/index.js
@@ -1,0 +1,673 @@
+// Git Diff — runs git in a session's working folder and renders the patch with diff2html.
+// Nothing here writes to the repository: no add, no index updates, read-only commands only.
+
+const { execFile } = require('child_process');
+const { readFileSync, statSync, readlinkSync } = require('fs');
+const { homedir } = require('os');
+const { join, dirname } = require('path');
+const d2h = require('diff2html');
+const hljs = require('highlight.js');
+
+const EMPTY_TREE = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
+const GIT_TIMEOUT = 15000;
+const MAX_BUFFER = 64 * 1024 * 1024;
+const MAX_UNTRACKED_BYTES = 512 * 1024; // larger untracked files are listed, not rendered
+const BINARY_SNIFF_BYTES = 8000;
+const HIGHLIGHT_MAX_LINES = 6000;      // above this, skip highlighting to keep the tab responsive
+const HIGHLIGHT_MAX_LINE_CHARS = 2000; // minified or generated lines are not worth colouring
+const CACHE_MAX = 20;
+const CACHE_TTL = 5 * 60 * 1000;
+
+// GIT_OPTIONAL_LOCKS=0 stops `git diff` taking index.lock to refresh the index stat cache.
+// Without it, polling a folder where an agent is also running git can collide on that lock.
+// GIT_TERMINAL_PROMPT=0 stops git ever blocking on a credential prompt.
+const GIT_ENV = { ...process.env, GIT_OPTIONAL_LOCKS: '0', GIT_TERMINAL_PROMPT: '0' };
+
+// Run git and never throw — callers branch on ok.
+function runGit(args, cwd) {
+  return new Promise((resolve) => {
+    execFile('git', args, { cwd, env: GIT_ENV, timeout: GIT_TIMEOUT, maxBuffer: MAX_BUFFER, windowsHide: true, encoding: 'buffer' }, (err, stdout, stderr) => {
+      const out = (stdout || Buffer.alloc(0)).toString('utf8');
+      const errOut = (stderr || Buffer.alloc(0)).toString('utf8');
+      if (!err) return resolve({ ok: true, stdout: out, stderr: errOut });
+      resolve({
+        ok: false,
+        stdout: out,
+        stderr: errOut,
+        missing: err.code === 'ENOENT',
+        timedOut: !!err.killed,
+        message: errOut.trim() || err.message,
+      });
+    });
+  });
+}
+
+async function resolveRepo(cwd) {
+  const top = await runGit(['rev-parse', '--show-toplevel'], cwd);
+  if (!top.ok) {
+    if (top.missing) return { ok: false, code: 'no-git', message: 'git was not found on PATH' };
+    if (top.timedOut) return { ok: false, code: 'timeout', message: 'git rev-parse timed out' };
+    return { ok: false, code: 'not-a-repo', message: `Not a git repository: ${cwd}` };
+  }
+  const repoRoot = top.stdout.trim();
+  if (!repoRoot) return { ok: false, code: 'not-a-repo', message: `Not a git repository: ${cwd}` };
+
+  const named = await runGit(['rev-parse', '--abbrev-ref', 'HEAD'], repoRoot);
+  let branch = named.ok ? named.stdout.trim() : '';
+  if (!branch || branch === 'HEAD') {
+    const short = await runGit(['rev-parse', '--short', 'HEAD'], repoRoot);
+    branch = short.ok && short.stdout.trim() ? `detached at ${short.stdout.trim()}` : 'no commits yet';
+  }
+  return { ok: true, repoRoot, branch };
+}
+
+async function hasCommits(repoRoot) {
+  const head = await runGit(['rev-parse', '--verify', '--quiet', 'HEAD'], repoRoot);
+  return head.ok && !!head.stdout.trim();
+}
+
+// Which commit the diff is taken against, and what to call it in the header.
+async function resolveBase(repoRoot, scope, baseBranchSetting) {
+  const committed = await hasCommits(repoRoot);
+  const localBase = committed ? 'HEAD' : EMPTY_TREE;
+  const localLabel = committed ? 'HEAD' : 'empty repo';
+
+  if (scope !== 'base') return { base: localBase, baseLabel: localLabel, baseFallback: false };
+  if (!committed) return { base: localBase, baseLabel: localLabel, baseFallback: true };
+
+  const candidates = [];
+  if (baseBranchSetting) {
+    candidates.push(baseBranchSetting);
+  } else {
+    const originHead = await runGit(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], repoRoot);
+    if (originHead.ok && originHead.stdout.trim()) candidates.push(originHead.stdout.trim());
+    candidates.push('origin/main', 'origin/master', 'main', 'master');
+  }
+
+  const head = await runGit(['rev-parse', 'HEAD'], repoRoot);
+  const headSha = head.ok ? head.stdout.trim() : '';
+
+  for (const candidate of candidates) {
+    const exists = await runGit(['rev-parse', '--verify', '--quiet', `${candidate}^{commit}`], repoRoot);
+    if (!exists.ok || !exists.stdout.trim()) continue;
+    const mergeBase = await runGit(['merge-base', 'HEAD', candidate], repoRoot);
+    if (!mergeBase.ok || !mergeBase.stdout.trim()) continue;
+    const base = mergeBase.stdout.trim();
+    // On the base branch itself the merge base is HEAD, so this scope shows nothing extra.
+    return { base, baseLabel: candidate, baseFallback: false, baseIsHead: base === headSha };
+  }
+  // Nothing to compare against — show uncommitted work instead and say so.
+  return { base: localBase, baseLabel: localLabel, baseFallback: true };
+}
+
+// Every worktree attached to this repository, main checkout included. A session started in
+// the main checkout can therefore offer its worktrees as targets, which is the common case
+// when an agent works on a branch in a worktree.
+async function listWorktrees(repoRoot) {
+  const listed = await runGit(['worktree', 'list', '--porcelain'], repoRoot);
+  if (!listed.ok) return [];
+  const trees = [];
+  let current = null;
+  for (const line of listed.stdout.split('\n')) {
+    if (line.startsWith('worktree ')) {
+      current = { path: line.slice(9).trim(), branch: '', detached: false, bare: false };
+      trees.push(current);
+    } else if (!current) {
+      continue;
+    } else if (line.startsWith('branch ')) {
+      current.branch = line.slice(7).trim().replace(/^refs\/heads\//, '');
+    } else if (line === 'detached') {
+      current.detached = true;
+    } else if (line === 'bare') {
+      current.bare = true;
+    }
+  }
+  return trees.filter((t) => t.path && !t.bare);
+}
+
+// --- live working directory of a session's process (Linux) ---
+//
+// api.getSession() reports where a session was spawned, not where its shell or agent has since
+// moved, so a session whose agent has cd'd into a worktree still reports the original folder.
+// Reading /proc/<pid>/cwd answers that, but it needs the session's process id.
+//
+// CliDeck does not currently include a pid in the projection from api.getSession(), so this
+// stays inert and the folder falls back to where the session was spawned. The folder selector
+// still lists the session folder and every worktree of the repository, so the common case is
+// covered either way.
+//
+// A pid can be dug out of core's internals from here, by finding the already-loaded
+// sessions.js in require.cache and reading pty.pid off the live session map. That is
+// deliberately not done: it bypasses the projection the plugin API exists to provide, hands
+// over the whole pty object rather than one field, and would break silently on any rename or
+// refactor. UPSTREAM.md proposes the two-line addition to plugin-loader.js instead. When that
+// lands, this starts working with no change here.
+
+const LIVE_CWD_SUPPORTED = process.platform === 'linux';
+
+function ptyPid(session) {
+  return session && Number.isInteger(session.pid) && session.pid > 0 ? session.pid : 0;
+}
+
+function procCwd(pid) {
+  try { return readlinkSync(`/proc/${pid}/cwd`); } catch { return ''; }
+}
+
+function procName(pid) {
+  try { return readFileSync(`/proc/${pid}/comm`, 'utf8').trim(); } catch { return ''; }
+}
+
+// Where the session's own command is sitting right now. Only that process is inspected, not
+// anything it launched.
+function liveFolders(session) {
+  if (!LIVE_CWD_SUPPORTED) return [];
+  const pid = ptyPid(session);
+  if (!pid) return [];
+  const cwd = procCwd(pid);
+  return cwd ? [{ path: cwd, process: procName(pid) || `pid ${pid}` }] : [];
+}
+
+// The folder to diff. An explicit client choice wins. Otherwise prefer where the session's
+// processes actually are, falling back to where it was spawned.
+function resolveFolder(session, requested) {
+  if (typeof requested === 'string' && requested) {
+    try {
+      if (statSync(requested).isDirectory()) return { folder: requested, rejected: false };
+    } catch { /* fall through below */ }
+    return { folder: defaultFolder(session), rejected: true };
+  }
+  return { folder: defaultFolder(session), rejected: false };
+}
+
+// Prefer where the session's command actually is. It only wins over the spawn folder when it
+// is inside a repository, so a session sitting somewhere unrelated does not open on an error.
+function defaultFolder(session) {
+  const live = liveFolders(session)[0];
+  if (!live || live.path === session.cwd) return session.cwd;
+  if (looksLikeRepo(live.path)) return live.path;
+  return looksLikeRepo(session.cwd) ? session.cwd : live.path;
+}
+
+function looksLikeRepo(dir) {
+  let current = dir;
+  for (let i = 0; i < 40; i++) {
+    try {
+      if (statSync(join(current, '.git')) ) return true;
+    } catch { /* keep walking up */ }
+    const parent = dirname(current);
+    if (parent === current) return false;
+    current = parent;
+  }
+  return false;
+}
+
+function isBinaryBuffer(buf) {
+  return buf.subarray(0, BINARY_SNIFF_BYTES).includes(0);
+}
+
+// Build an added-file patch for an untracked file. Synthesising avoids `git diff --no-index
+// /dev/null` (no such path on Windows) and `git add -N` (which would touch the index).
+// Returns { patch, oversized } so the caller can tell "too large to show" apart from "binary".
+function synthesiseAddedFile(repoRoot, relPath) {
+  const header = `diff --git a/${relPath} b/${relPath}\nnew file mode 100644\n`;
+  const placeholder = `${header}Binary files /dev/null and b/${relPath} differ\n`;
+
+  let buf;
+  try {
+    buf = readFileSync(join(repoRoot, relPath));
+  } catch {
+    return null; // vanished or unreadable between listing and reading
+  }
+  if (buf.length > MAX_UNTRACKED_BYTES) return { patch: placeholder, oversized: true, bytes: buf.length };
+  if (isBinaryBuffer(buf)) return { patch: placeholder, oversized: false, bytes: buf.length };
+  if (buf.length === 0) return { patch: header, oversized: false, bytes: 0 }; // new but empty, no hunk
+
+  const text = buf.toString('utf8');
+  const endsWithNewline = text.endsWith('\n');
+  const lines = (endsWithNewline ? text.slice(0, -1) : text).split('\n');
+  const body = lines.map((l) => `+${l}`).join('\n');
+  const noNewline = endsWithNewline ? '' : '\n\\ No newline at end of file';
+  return {
+    patch: `${header}--- /dev/null\n+++ b/${relPath}\n@@ -0,0 +1,${lines.length} @@\n${body}${noNewline}\n`,
+    oversized: false,
+    bytes: buf.length,
+  };
+}
+
+async function untrackedPatch(repoRoot) {
+  const listed = await runGit(['ls-files', '--others', '--exclude-standard', '-z'], repoRoot);
+  if (!listed.ok) return { patch: '', oversized: new Map() };
+  const paths = listed.stdout.split('\0').filter(Boolean).sort();
+  const parts = [];
+  const oversized = new Map(); // path → byte size, for files we listed but did not render
+  for (const relPath of paths) {
+    const result = synthesiseAddedFile(repoRoot, relPath);
+    if (!result) continue;
+    parts.push(result.patch);
+    if (result.oversized) oversized.set(relPath, result.bytes);
+  }
+  return { patch: parts.join(''), oversized };
+}
+
+async function buildDiff(cwd, scope, settings) {
+  const repo = await resolveRepo(cwd);
+  if (!repo.ok) return repo;
+
+  const { repoRoot, branch } = repo;
+  const { base, baseLabel, baseFallback, baseIsHead } = await resolveBase(repoRoot, scope, String(settings.baseBranch || '').trim());
+
+  const context = Number.isFinite(settings.contextLines) ? Math.max(0, Math.min(20, settings.contextLines)) : 3;
+  const tracked = await runGit(
+    ['-c', 'core.quotepath=false', 'diff', '--no-color', '--find-renames', `-U${context}`, base],
+    repoRoot,
+  );
+  if (!tracked.ok) {
+    if (tracked.timedOut) return { ok: false, code: 'timeout', message: 'git diff timed out' };
+    return { ok: false, code: 'git-failed', message: tracked.message || 'git diff failed' };
+  }
+
+  const untracked = await untrackedPatch(repoRoot);
+  const patch = tracked.stdout + untracked.patch;
+  const maxChanges = Number.isFinite(settings.maxChanges) ? Math.max(100, settings.maxChanges) : 20000;
+  // diffMaxChanges is a parse-time option and applies per file, so it caps one enormous file.
+  const parsed = d2h.parse(patch, {
+    diffMaxChanges: maxChanges,
+    diffTooBigMessage: () => 'File has too many changes to display',
+  });
+
+  const totals = parsed.reduce(
+    (acc, f) => ({
+      files: acc.files + 1,
+      additions: acc.additions + (f.addedLines || 0),
+      deletions: acc.deletions + (f.deletedLines || 0),
+    }),
+    { files: 0, additions: 0, deletions: 0 },
+  );
+
+  const files = parsed.map((f) => {
+    const path = f.newName && f.newName !== '/dev/null' ? f.newName : f.oldName;
+    return {
+      path,
+      oldPath: f.isRename ? f.oldName : '',
+      additions: f.addedLines || 0,
+      deletions: f.deletedLines || 0,
+      isNew: !!f.isNew,
+      isDeleted: !!f.isDeleted,
+      isRename: !!f.isRename,
+      // An oversized untracked file uses git's binary placeholder to render, but it is text —
+      // report it separately so the UI does not call it binary.
+      isBinary: !!f.isBinary && !untracked.oversized.has(path),
+      isTooBig: !!f.isTooBig,
+      oversizedBytes: untracked.oversized.get(path) || 0,
+    };
+  });
+
+  // Separate whole-diff guard: diffMaxChanges never fires on a diff made of thousands of
+  // small files, which is exactly the case that would lock up the browser tab.
+  const tooBig = totals.additions + totals.deletions > maxChanges;
+
+  const worktrees = await listWorktrees(repoRoot);
+
+  return {
+    ok: true, repoRoot, branch, base, baseLabel, baseFallback, baseIsHead: !!baseIsHead,
+    patch, parsed, totals, files, tooBig, maxChanges, worktrees,
+  };
+}
+
+function renderHtml(built, layout, settings) {
+  if (built.tooBig) return ''; // client renders its own file list instead
+  const html = d2h.html(built.parsed, {
+    outputFormat: layout === 'line-by-line' ? 'line-by-line' : 'side-by-side',
+    drawFileList: true,
+    colorScheme: 'dark',
+    matching: 'words',
+    renderNothingWhenEmpty: false,
+  });
+  const changed = built.totals.additions + built.totals.deletions;
+  if (settings.syntaxHighlight === false || changed > HIGHLIGHT_MAX_LINES) return html;
+  return highlightHtml(html);
+}
+
+// --- syntax highlighting ---
+//
+// diff2html only highlights in the browser, through its diff2html-ui bundle, which pulls in a
+// megabyte of highlight.js. Since rendering already happens here, highlighting happens here
+// too and the browser receives finished markup plus a small theme stylesheet.
+//
+// The wrinkle is word-level diffing: each rendered line already contains <ins> and <del> from
+// diff2html, and highlight.js wants plain text. diff2html-ui reconciles the two by walking DOM
+// node streams, which needs a document. Instead the two are merged by character offset below.
+
+// diff2html puts the file extension in data-lang. highlight.js accepts extensions directly as
+// language aliases, so no mapping table is needed. Aliases are then resolved to canonical ids
+// so the emitted class is "javascript" whether the file was .js, .mjs or .cjs. Built once by
+// matching each registered language object against the alias, since highlight.js exposes no
+// alias-to-id call.
+const PLAINTEXT = hljs.getLanguage('plaintext');
+const CANONICAL_LANGUAGE = new Map();
+for (const id of hljs.listLanguages()) CANONICAL_LANGUAGE.set(hljs.getLanguage(id), id);
+
+// Returns the canonical language id, or '' when there is nothing worth colouring, which covers
+// both unknown extensions and ones that resolve to plain text.
+function languageFor(extension) {
+  if (!extension) return '';
+  const language = hljs.getLanguage(extension);
+  if (!language || language === PLAINTEXT) return '';
+  return CANONICAL_LANGUAGE.get(language) || extension;
+}
+
+const NAMED_ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ' };
+
+function decodeEntities(text) {
+  return text.replace(/&(#[xX][0-9a-fA-F]+|#\d+|[a-zA-Z]+);/g, (whole, code) => {
+    if (code[0] === '#') {
+      const value = code[1] === 'x' || code[1] === 'X'
+        ? Number.parseInt(code.slice(2), 16)
+        : Number.parseInt(code.slice(1), 10);
+      if (!Number.isFinite(value) || value < 0 || value > 0x10ffff) return whole;
+      try { return String.fromCodePoint(value); } catch { return whole; }
+    }
+    return NAMED_ENTITIES[code] ?? whole;
+  });
+}
+
+function escapeChar(ch) {
+  if (ch === '&') return '&amp;';
+  if (ch === '<') return '&lt;';
+  if (ch === '>') return '&gt;';
+  if (ch === '"') return '&quot;';
+  return ch;
+}
+
+// A rendered line into plain characters plus which of them diff2html marked as inserted or
+// deleted. Returns null for anything other than ins/del markup, so unexpected input is left
+// untouched rather than mangled.
+function splitLineMarks(inner) {
+  const chars = [];
+  const marks = [];
+  let mark = '';
+  let index = 0;
+  const token = /<(\/?)(ins|del)>|([^<]+)/g;
+  let match;
+  while ((match = token.exec(inner)) !== null) {
+    if (match.index !== index) return null; // skipped over markup we do not understand
+    index = token.lastIndex;
+    if (match[2]) { mark = match[1] ? '' : match[2]; continue; }
+    for (const ch of decodeEntities(match[3])) { chars.push(ch); marks.push(mark); }
+  }
+  return index === inner.length ? { chars, marks } : null;
+}
+
+// highlight.js output into the same shape: one class stack per character.
+function splitHighlighted(html) {
+  const chars = [];
+  const stacks = [];
+  const stack = [];
+  let index = 0;
+  const token = /<span class="([^"]*)">|<\/span>|([^<]+)/g;
+  let match;
+  while ((match = token.exec(html)) !== null) {
+    if (match.index !== index) return null;
+    index = token.lastIndex;
+    if (match[1] !== undefined) { stack.push(match[1]); continue; }
+    if (match[2] === undefined) { stack.pop(); continue; }
+    for (const ch of decodeEntities(match[2])) { chars.push(ch); stacks.push(stack.slice()); }
+  }
+  return index === html.length ? { chars, stacks } : null;
+}
+
+function sameStack(a, b) {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+// Re-emit the line with the ins/del mark on the outside and highlight spans nested inside.
+//
+// The nesting order matters. Where a marked range and a token overlap only partially, one of
+// the two has to be split, and diff2html styles ins/del with a border radius and
+// inline-block, so splitting a mark shows up as two rounded boxes with a seam mid-word.
+// Highlight spans carry only a colour, so splitting those is invisible. Marks therefore stay
+// whole and spans are closed and reopened around them.
+function weave(chars, stacks, marks) {
+  let out = '';
+  let openStack = [];
+  let openMark = '';
+  for (let i = 0; i < chars.length; i++) {
+    const stack = stacks[i];
+    const mark = marks[i];
+    if (mark !== openMark) {
+      out += '</span>'.repeat(openStack.length);
+      if (openMark) out += `</${openMark}>`;
+      openStack = [];
+      openMark = mark;
+      if (mark) out += `<${mark}>`;
+    }
+    if (!sameStack(stack, openStack)) {
+      out += '</span>'.repeat(openStack.length);
+      for (const cls of stack) out += `<span class="${cls}">`;
+      openStack = stack;
+    }
+    out += escapeChar(chars[i]);
+  }
+  out += '</span>'.repeat(openStack.length);
+  if (openMark) out += `</${openMark}>`;
+  return out;
+}
+
+function highlightLine(inner, language) {
+  const split = splitLineMarks(inner);
+  if (!split || !split.chars.length || split.chars.length > HIGHLIGHT_MAX_LINE_CHARS) return null;
+  let result;
+  try {
+    result = hljs.highlight(split.chars.join(''), { language, ignoreIllegals: true });
+  } catch { return null; }
+  const highlighted = splitHighlighted(result.value);
+  // Bail unless the highlighter returned exactly the same characters back.
+  if (!highlighted || highlighted.chars.length !== split.chars.length) return null;
+  return weave(highlighted.chars, highlighted.stacks, split.marks);
+}
+
+function highlightHtml(html) {
+  let language = '';
+  return html.replace(
+    /data-lang="([^"]*)"|<span class="d2h-code-line-ctn">([\s\S]*?)<\/span>/g,
+    (whole, dataLang, inner) => {
+      if (dataLang !== undefined) { language = languageFor(dataLang); return whole; }
+      if (!language) return whole; // unknown or plain text, nothing to colour
+      const woven = highlightLine(inner, language);
+      return woven === null ? whole : `<span class="d2h-code-line-ctn hljs ${language}">${woven}</span>`;
+    },
+  );
+}
+
+// The chosen highlight.js theme, read from the installed package. Only the token colours are
+// wanted, so the theme's own background is neutralised in git-diff.css.
+const themeCache = new Map();
+function highlightStyles(theme) {
+  const name = /^[a-z0-9-]+$/.test(String(theme || '')) ? theme : 'github-dark';
+  if (themeCache.has(name)) return themeCache.get(name);
+  let css = '';
+  for (const candidate of [name, 'github-dark']) {
+    try {
+      css = readFileSync(require.resolve(`highlight.js/styles/${candidate}.min.css`), 'utf8');
+      break;
+    } catch { /* try the fallback theme */ }
+  }
+  themeCache.set(name, css);
+  return css;
+}
+
+let stylesCache = null;
+function diff2htmlStyles() {
+  if (stylesCache !== null) return stylesCache;
+  try {
+    // No "exports" field in diff2html's package.json, so the deep path resolves.
+    stylesCache = readFileSync(require.resolve('diff2html/bundles/css/diff2html.min.css'), 'utf8');
+  } catch {
+    // Fall back to walking up from the module entry point.
+    try {
+      const pkgDir = dirname(dirname(require.resolve('diff2html')));
+      stylesCache = readFileSync(join(pkgDir, 'bundles', 'css', 'diff2html.min.css'), 'utf8');
+    } catch {
+      stylesCache = '';
+    }
+  }
+  return stylesCache;
+}
+
+module.exports = {
+  init(api) {
+    // sessionId → last built diff, so a layout toggle re-renders instead of re-running git.
+    const cache = new Map();
+    // sessionId → newest requestId, so a superseded poll's reply is dropped.
+    const newest = new Map();
+
+    function pruneCache() {
+      const now = Date.now();
+      for (const [id, entry] of cache) {
+        if (now - entry.at > CACHE_TTL || !api.getSession(id)) cache.delete(id);
+      }
+      while (cache.size > CACHE_MAX) cache.delete(cache.keys().next().value);
+      for (const id of newest.keys()) {
+        if (!api.getSession(id)) newest.delete(id);
+      }
+    }
+
+    function cacheKey(settings, folder) {
+      return `${folder}|${settings.contextLines}|${settings.maxChanges}|${settings.baseBranch || ''}`;
+    }
+
+    // Folders the client can switch between: wherever the session's processes currently are,
+    // where the session started, and every worktree of the repository in view. The folder in
+    // use is always present so the selector can always show it.
+    function folderChoices(session, built, folder) {
+      const seen = new Map();
+      const add = (path, label, kind) => {
+        if (!path || seen.has(path)) return;
+        seen.set(path, { path, label, kind });
+      };
+      for (const live of liveFolders(session)) add(live.path, live.process, 'live');
+      add(session.cwd, 'session start', 'session');
+      for (const tree of built.worktrees || []) {
+        add(tree.path, tree.branch || (tree.detached ? 'detached' : ''), tree.path === built.repoRoot ? 'current-worktree' : 'worktree');
+      }
+      add(folder, '', 'current');
+      return [...seen.values()];
+    }
+
+    // Errors still carry the folder and the session's own folder, so the selector stays
+    // usable — otherwise picking a folder that is not a repository would be a dead end.
+    function fail(msg, code, message, folder) {
+      const session = api.getSession(msg.sessionId);
+      const choices = [];
+      if (session?.cwd) choices.push({ path: session.cwd, label: 'Session folder', kind: 'session' });
+      if (folder && folder !== session?.cwd) choices.push({ path: folder, label: '', kind: 'current' });
+      api.sendToFrontend('diff', {
+        requestId: msg.requestId,
+        sessionId: msg.sessionId,
+        ok: false,
+        code,
+        message,
+        folder: folder || session?.cwd || '',
+        folders: choices,
+        home: homedir(),
+      });
+    }
+
+    function reply(msg, built, layout, session, folder, folderRejected) {
+      api.sendToFrontend('diff', {
+        requestId: msg.requestId,
+        sessionId: msg.sessionId,
+        ok: true,
+        sessionName: session.name,
+        cwd: session.cwd,
+        folder,
+        folderRejected: !!folderRejected,
+        folders: folderChoices(session, built, folder),
+        home: homedir(),
+        repoRoot: built.repoRoot,
+        branch: built.branch,
+        scope: msg.scope === 'base' ? 'base' : 'uncommitted',
+        layout,
+        baseLabel: built.baseLabel,
+        baseFallback: built.baseFallback,
+        baseIsHead: built.baseIsHead,
+        totals: built.totals,
+        files: built.files,
+        tooBig: built.tooBig,
+        maxChanges: built.maxChanges,
+        html: renderHtml(built, layout, api.getSettings()),
+      });
+    }
+
+    async function handleDiff(msg) {
+      const session = api.getSession(msg.sessionId);
+      if (!session || !session.cwd) return fail(msg, 'no-session', 'Session is no longer running');
+
+      newest.set(msg.sessionId, msg.requestId);
+      const settings = api.getSettings();
+      const scope = msg.scope === 'base' ? 'base' : 'uncommitted';
+      const layout = msg.layout === 'line-by-line' ? 'line-by-line' : 'side-by-side';
+      const { folder, rejected } = resolveFolder(session, msg.folder);
+
+      let built;
+      try {
+        built = await buildDiff(folder, scope, settings);
+      } catch (e) {
+        return fail(msg, 'git-failed', e.message);
+      }
+      if (newest.get(msg.sessionId) !== msg.requestId) return; // a newer request already went out
+      if (!built.ok) return fail(msg, built.code, built.message, folder);
+
+      pruneCache();
+      cache.set(msg.sessionId, { scope, folder, key: cacheKey(settings, folder), at: Date.now(), built });
+      reply(msg, built, layout, session, folder, rejected);
+    }
+
+    api.onFrontendMessage('diff', handleDiff);
+
+    // Layout toggle — reuse the cached patch when it still matches, otherwise re-run git.
+    api.onFrontendMessage('render', async (msg) => {
+      const session = api.getSession(msg.sessionId);
+      if (!session || !session.cwd) return fail(msg, 'no-session', 'Session is no longer running');
+
+      const scope = msg.scope === 'base' ? 'base' : 'uncommitted';
+      const layout = msg.layout === 'line-by-line' ? 'line-by-line' : 'side-by-side';
+      const { folder } = resolveFolder(session, msg.folder);
+      const entry = cache.get(msg.sessionId);
+
+      if (entry && entry.scope === scope && entry.key === cacheKey(api.getSettings(), folder)) {
+        newest.set(msg.sessionId, msg.requestId);
+        return reply(msg, entry.built, layout, session, folder, false);
+      }
+      return handleDiff(msg);
+    });
+
+    api.onFrontendMessage('getPatch', (msg) => {
+      const entry = cache.get(msg.sessionId);
+      api.sendToFrontend('patch', {
+        requestId: msg.requestId,
+        sessionId: msg.sessionId,
+        patch: entry ? entry.built.patch : '',
+      });
+    });
+
+    api.onFrontendMessage('getStyles', () => {
+      const settings = api.getSettings();
+      api.sendToFrontend('styles', {
+        css: diff2htmlStyles(),
+        hljsCss: settings.syntaxHighlight === false ? '' : highlightStyles(settings.highlightTheme),
+        theme: settings.highlightTheme || 'github-dark',
+        highlight: settings.syntaxHighlight !== false,
+      });
+    });
+
+    api.onFrontendMessage('getSettings', () => {
+      api.sendToFrontend('settings', api.getSettings());
+    });
+    api.onSettingsChange(() => {
+      api.sendToFrontend('settings', api.getSettings());
+    });
+  },
+};

--- a/plugins/git-diff/package-lock.json
+++ b/plugins/git-diff/package-lock.json
@@ -1,0 +1,81 @@
+{
+  "name": "clideck-plugin-git-diff",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "clideck-plugin-git-diff",
+      "dependencies": {
+        "diff2html": "^3.4.56"
+      }
+    },
+    "node_modules/@profoundlogic/hogan": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@profoundlogic/hogan/-/hogan-3.0.4.tgz",
+      "integrity": "sha512-pmNVGuooS30Mm7YbZd5T7E5zYVO6D5Ct91sn4T39mUvMUc3sCGridcnhAufL1/Bz2QzAtzEn0agNrdk3+5yWzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "nopt": "1.0.10"
+      },
+      "bin": {
+        "hulk": "bin/hulk"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "license": "ISC"
+    },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/diff2html": {
+      "version": "3.4.56",
+      "resolved": "https://registry.npmjs.org/diff2html/-/diff2html-3.4.56.tgz",
+      "integrity": "sha512-u9gfn+BlbHcyO7vItCIC4z49LJDUt31tODzOfAuJ5R1E7IdlRL6KjugcB9zOpejD+XiR+dDZbsnHSQ3g6A/u8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@profoundlogic/hogan": "^3.0.4",
+        "diff": "^8.0.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "highlight.js": "11.11.1"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
+      "license": "MIT",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    }
+  }
+}

--- a/plugins/git-diff/package.json
+++ b/plugins/git-diff/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "clideck-plugin-git-diff",
+  "private": true,
+  "dependencies": {
+    "diff2html": "^3.4.56",
+    "highlight.js": "^11.11.1"
+  }
+}

--- a/plugins/git-diff/public/git-diff.css
+++ b/plugins/git-diff/public/git-diff.css
@@ -1,0 +1,303 @@
+/* Git Diff — modal chrome only. The diff body itself is styled by diff2html's own
+   stylesheet in its dark colour scheme; the overrides at the bottom just make it sit
+   comfortably inside CliDeck. Plain CSS, because Tailwind only compiles classes it
+   finds under the app's public/ folder. */
+
+.gd-overlay {
+  position: fixed;
+  inset: 0;
+  /* Above the app and the remote modal (260), below the shared folder picker (300) so it
+     opens on top of this one, and below toasts (500). */
+  z-index: 280;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(2px);
+}
+.gd-overlay[hidden] { display: none; }
+
+/* Maximised: fill the browser window, no inset frame. */
+.gd-overlay.gd-max { padding: 0; }
+.gd-overlay.gd-max .gd-panel {
+  max-width: none;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.gd-panel {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 1600px;
+  height: 100%;
+  max-height: 100%;
+  overflow: hidden;
+  background: #0f172a;
+  border: 1px solid rgba(51, 65, 85, 0.6);
+  border-radius: 12px;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.55);
+  color: #e2e8f0;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+/* --- header --- */
+
+.gd-head {
+  flex: 0 0 auto;
+  padding: 10px 14px;
+  border-bottom: 1px solid rgba(51, 65, 85, 0.6);
+  background: rgba(30, 41, 59, 0.5);
+}
+.gd-head-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+.gd-head-row + .gd-head-row { margin-top: 10px; }
+
+.gd-icon { display: flex; color: #818cf8; flex: 0 0 auto; }
+.gd-icon svg { width: 16px; height: 16px; }
+
+.gd-session {
+  font-size: 13px;
+  font-weight: 600;
+  color: #e2e8f0;
+  white-space: nowrap;
+}
+.gd-branch {
+  flex: 0 0 auto;
+  padding: 1px 7px;
+  font-size: 11px;
+  color: #a5b4fc;
+  background: rgba(129, 140, 248, 0.12);
+  border: 1px solid rgba(129, 140, 248, 0.25);
+  border-radius: 999px;
+  white-space: nowrap;
+}
+/* Folder selector: the session's own folder, every worktree of the repository, and an
+   entry that opens the app's directory picker. */
+.gd-folder {
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 100%;
+  padding: 3px 8px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: #94a3b8;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(51, 65, 85, 0.8);
+  border-radius: 7px;
+  outline: none;
+  cursor: pointer;
+  text-overflow: ellipsis;
+}
+.gd-folder:hover { color: #e2e8f0; border-color: rgba(99, 102, 241, 0.5); }
+.gd-folder:focus { border-color: #6366f1; }
+.gd-folder option { background: #1e293b; color: #e2e8f0; }
+
+.gd-controls { flex-wrap: wrap; }
+.gd-spacer { flex: 1 1 auto; }
+
+.gd-summary {
+  font-size: 12px;
+  color: #94a3b8;
+  white-space: nowrap;
+}
+.gd-add { color: #4ade80; }
+.gd-del { color: #f87171; }
+
+/* segmented control */
+.gd-seg {
+  display: inline-flex;
+  overflow: hidden;
+  border: 1px solid rgba(51, 65, 85, 0.8);
+  border-radius: 7px;
+  background: rgba(15, 23, 42, 0.8);
+}
+.gd-seg button {
+  padding: 4px 10px;
+  font: inherit;
+  font-size: 11px;
+  color: #94a3b8;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  transition: color 0.12s, background-color 0.12s;
+  white-space: nowrap;
+}
+.gd-seg button + button { border-left: 1px solid rgba(51, 65, 85, 0.8); }
+.gd-seg button:hover { color: #e2e8f0; background: rgba(51, 65, 85, 0.5); }
+.gd-seg button.gd-on { color: #c7d2fe; background: rgba(99, 102, 241, 0.22); }
+
+.gd-btn {
+  padding: 4px 10px;
+  font: inherit;
+  font-size: 11px;
+  color: #94a3b8;
+  background: rgba(30, 41, 59, 0.8);
+  border: 1px solid rgba(51, 65, 85, 0.5);
+  border-radius: 7px;
+  cursor: pointer;
+  transition: color 0.12s, background-color 0.12s;
+  white-space: nowrap;
+}
+.gd-btn:hover:not(:disabled) { color: #e2e8f0; background: #334155; }
+.gd-btn:disabled { opacity: 0.4; cursor: default; }
+
+.gd-icon-btn {
+  padding: 3px 8px;
+  font-size: 12px;
+  line-height: 1;
+  flex: 0 0 auto;
+}
+
+.gd-refresh.gd-busy {
+  color: #818cf8;
+  animation: gd-pulse 1s ease-in-out infinite;
+}
+@keyframes gd-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.45; }
+}
+
+.gd-note {
+  flex: 0 0 auto;
+  padding: 7px 14px;
+  font-size: 11px;
+  color: #fcd34d;
+  background: rgba(180, 130, 20, 0.12);
+  border-bottom: 1px solid rgba(180, 130, 20, 0.25);
+}
+.gd-note[hidden] { display: none; }
+
+/* --- body --- */
+
+.gd-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  padding: 12px 14px 20px;
+}
+
+.gd-state {
+  padding: 28px 8px;
+  font-size: 12px;
+  color: #64748b;
+  text-align: center;
+}
+.gd-error-title {
+  margin-bottom: 8px;
+  font-size: 13px;
+  color: #e2e8f0;
+}
+.gd-error-detail {
+  display: inline-block;
+  max-width: 100%;
+  padding: 8px 10px;
+  overflow-x: auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: #f87171;
+  text-align: left;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(248, 113, 113, 0.25);
+  border-radius: 7px;
+  white-space: pre-wrap;
+}
+.gd-toobig p {
+  max-width: 620px;
+  margin: 0 auto;
+  line-height: 1.5;
+}
+
+.gd-big-list {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 0;
+  list-style: none;
+}
+.gd-big-row {
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+  padding: 5px 10px;
+  border-bottom: 1px solid rgba(51, 65, 85, 0.4);
+}
+.gd-big-path {
+  flex: 1 1 auto;
+  overflow: hidden;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  color: #cbd5e1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.gd-big-stats {
+  flex: 0 0 auto;
+  font-size: 11px;
+}
+
+/* --- diff2html overrides --- */
+
+/* Its hide/show links need the diff2html-ui bundle we deliberately do not load. */
+.gd-body .d2h-file-switch { display: none; }
+
+/* Header doubles as the per-file collapse control. */
+.gd-body .d2h-file-header { cursor: pointer; }
+.gd-body .d2h-file-header:hover { filter: brightness(1.25); }
+.gd-body .d2h-file-collapse { display: none; }
+
+.gd-body .d2h-file-wrapper.gd-collapsed .d2h-file-diff,
+.gd-body .d2h-file-wrapper.gd-collapsed .d2h-files-diff { display: none; }
+
+.gd-body .d2h-file-list-wrapper.gd-hidden .d2h-file-list,
+.gd-body .d2h-file-list-wrapper.gd-hidden .d2h-file-list-header { display: none; }
+.gd-body .d2h-file-list-wrapper.gd-hidden { border: 0; margin: 0; }
+
+/* Match the app's density: diff2html defaults are a size larger. */
+.gd-body .d2h-wrapper,
+.gd-body .d2h-file-list-wrapper { font-size: 12px; }
+.gd-body .d2h-code-line,
+.gd-body .d2h-code-side-line,
+.gd-body .d2h-code-line-ctn,
+.gd-body .d2h-code-linenumber,
+.gd-body .d2h-code-side-linenumber {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+}
+.gd-body .d2h-file-name { font-size: 12px; }
+
+/* Keep each file's header visible while scrolling through its hunks. */
+.gd-body .d2h-file-header {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+
+/* diff2html positions line numbers with `position: absolute` and ships no positioned
+   ancestor of its own, because it assumes the page is the scroll container. Here the
+   scroll container is .gd-body, so without this the numbers resolve against the fixed
+   .gd-overlay outside the scroller and stay put while the code scrolls past them.
+   Giving each file block a containing block inside the scroller pins them to their lines. */
+.gd-body .d2h-file-wrapper,
+.gd-body .d2h-file-diff,
+.gd-body .d2h-files-diff,
+.gd-body .d2h-file-side-diff {
+  position: relative;
+}
+
+/* --- syntax highlighting ---
+   The highlight.js theme paints .hljs with its own page background and padding, which would
+   cover diff2html's added and removed row colours. Only the token colours are wanted. */
+.gd-body .d2h-code-line-ctn.hljs {
+  background: transparent;
+  padding: 0;
+  display: inline;
+}
+/* Keep word-level insert and delete marks readable on top of coloured tokens. */
+.gd-body .d2h-code-line-ctn ins,
+.gd-body .d2h-code-line-ctn del { text-decoration: none; }


### PR DESCRIPTION
Shows the git diff of a session's working folder in a modal, without leaving CliDeck.

- Two scopes: uncommitted changes, or everything since the merge base with the base branch (origin/HEAD, then main, then master, or an explicit setting).
- Folder selector defaulting to where the session's process actually is, and listing every worktree of the repository, so a session in a main checkout can review work happening in a linked worktree.
- Split and unified layouts, per-file collapse, copy patch, maximise, and auto-refresh while the diff is open.
- Rendering and syntax highlighting run server-side through diff2html and highlight.js, so the browser receives finished markup plus a small theme stylesheet instead of a megabyte of bundled highlighter. Word-level ins/del marks and highlight spans are merged by character offset, with the marks kept whole because diff2html styles them with a border radius.
- Untracked files appear by synthesising an added-file patch, avoiding both `git diff --no-index /dev/null` (not portable to Windows) and `git add -N` (would mutate the index).
- Every git command is read-only and runs with GIT_OPTIONAL_LOCKS=0, so polling a folder where an agent is also running git cannot collide on index.lock.
- Guards for large diffs: per-file and whole-diff line caps, a byte cap on untracked files, and a per-line length cap.

The live working directory comes from /proc/<pid>/cwd, because the projection from api.getSession() reports where a session was spawned rather than where it is now. The plugin API does not expose the pty pid, so there is a feature-detected fallback that reads core's own session map; plugins/git-diff/UPSTREAM.md proposes the two-line core change that would make the fallback unnecessary.

No core files are modified.

## What changed

<!-- One or two sentences. What does this PR do? -->

## Why

<!-- What problem does this solve? Link to an issue or discussion if one exists. -->

## How to verify

<!--
Steps to test this locally:
1. Run `node server.js`
2. Open http://localhost:4000
3. ...
-->

## What's out of scope

<!-- What did you intentionally NOT change? Helps reviewers stay focused. -->

## Checklist

- [ ] Tested locally with `node server.js`
- [ ] One focused change, not bundled with unrelated fixes
- [ ] No new external service dependencies
- [ ] Does not read, store, or intercept agent prompts/responses
