### PR TITLE
fix: allow local agent commands on non-loopback binds

### DIFF
--- a/http-util.js
+++ b/http-util.js
@@ -3,9 +3,16 @@ function sendJson(res, status, payload) {
   res.end(JSON.stringify(payload));
 }
 
-function isLoopback(req) {
-  const addr = req.socket?.remoteAddress || '';
-  return addr === '::1' || addr === '127.0.0.1' || addr.startsWith('127.') || addr.startsWith('::ffff:127.');
+// A local child connecting to a specific interface bind has matching source
+// and destination addresses rather than a loopback source.
+function isSameHost(req) {
+  const normalize = addr => addr.startsWith('::ffff:') ? addr.slice(7) : addr;
+  const remote = normalize(req.socket?.remoteAddress || '');
+  const local = normalize(req.socket?.localAddress || '');
+  return remote === '::1'
+    || remote === '127.0.0.1'
+    || remote.startsWith('127.')
+    || (!!remote && !!local && remote === local);
 }
 
 function sameProject(a, b) {
@@ -22,4 +29,4 @@ function sessionAddress(session, id, projects) {
   return session.projectId ? `@${projectName(projects, session.projectId)}/${name}` : name;
 }
 
-module.exports = { sendJson, isLoopback, sameProject, projectName, sessionAddress };
+module.exports = { sendJson, isSameHost, sameProject, projectName, sessionAddress };

--- a/session-agents.js
+++ b/session-agents.js
@@ -1,4 +1,4 @@
-const { sendJson, isLoopback, sameProject, projectName, sessionAddress } = require('./http-util');
+const { sendJson, isSameHost, sameProject, projectName, sessionAddress } = require('./http-util');
 
 function agentRow(id, s, callerId, projects) {
   const project = projectName(projects, s.projectId);
@@ -34,8 +34,8 @@ function listProjectAgents(callerSessionId, sessionsApi, cfg = {}, all = false) 
 
 async function handleHttp(req, res, sessionsApi, getConfig = () => ({})) {
   try {
-    if (!isLoopback(req)) {
-      const err = new Error('CliDeck agents only accepts local requests');
+    if (!isSameHost(req)) {
+      const err = new Error('CliDeck agents only accepts same-host requests');
       err.status = 403;
       throw err;
     }

--- a/session-ask.js
+++ b/session-ask.js
@@ -1,5 +1,5 @@
 const transcript = require('./transcript');
-const { sendJson, isLoopback, sameProject, projectName, sessionAddress } = require('./http-util');
+const { sendJson, isSameHost, sameProject, projectName, sessionAddress } = require('./http-util');
 
 const MAX_BODY = 2 * 1024 * 1024;
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
@@ -230,7 +230,7 @@ async function askSession(payload, sessionsApi, cfg = {}) {
 
 async function handleHttp(req, res, sessionsApi, getConfig = () => ({})) {
   try {
-    if (!isLoopback(req)) throw jsonError('CliDeck ask only accepts local requests', 403);
+    if (!isSameHost(req)) throw jsonError('CliDeck ask only accepts same-host requests', 403);
     const payload = await readJson(req);
     const result = await askSession(payload, sessionsApi, getConfig() || {});
     sendJson(res, 200, result);

--- a/tests/http-util.test.js
+++ b/tests/http-util.test.js
@@ -1,0 +1,23 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { isSameHost } = require('../http-util');
+
+function request(remoteAddress, localAddress) {
+  return { socket: { remoteAddress, localAddress } };
+}
+
+test('accepts loopback and same-interface requests from this host', () => {
+  assert.equal(isSameHost(request('127.0.0.1', '127.0.0.1')), true);
+  assert.equal(isSameHost(request('::1', '::1')), true);
+  assert.equal(isSameHost(request('::ffff:127.0.0.1', '::ffff:192.0.2.10')), true);
+  assert.equal(isSameHost(request('192.0.2.10', '192.0.2.10')), true);
+  assert.equal(isSameHost(request('::ffff:192.0.2.10', '192.0.2.10')), true);
+  assert.equal(isSameHost(request('2001:db8::10', '2001:db8::10')), true);
+});
+
+test('rejects requests from another host or an incomplete socket', () => {
+  assert.equal(isSameHost(request('192.0.2.11', '192.0.2.10')), false);
+  assert.equal(isSameHost(request('2001:db8::11', '2001:db8::10')), false);
+  assert.equal(isSameHost(request('', '192.0.2.10')), false);
+  assert.equal(isSameHost(request('192.0.2.10', '')), false);
+});


### PR DESCRIPTION
## What changed

Treat requests as same-host when their socket source and destination addresses match, in addition to the existing loopback checks.

This updates the guards used by `clideck agents` and `clideck ask` and adds IPv4, IPv6, IPv4-mapped, and negative-address coverage.

## Why

CliDeck supports binding to a specific interface with `--host` and passes that address to managed sessions through `CLIDECK_URL`.

When a child session connects through a specific non-loopback address, Node reports matching socket source and destination addresses rather than a loopback source. The existing loopback-only guard therefore returns `403`, causing `clideck agents` and `clideck ask` to fail even though the request originated on the CliDeck host.

I encountered this while running CliDeck in a VM on an isolated VLAN. CliDeck binds to the VM's VLAN address so it can be reached through a reverse proxy protected by forward authentication. Browser traffic uses that proxy, while agent commands connect directly from inside the VM using the configured VLAN address.

This change does not trust forwarded headers or treat the reverse proxy as authentication for agent commands. It only recognizes a direct same-host socket connection; requests whose source address differs from the server's local address remain rejected.

## How to verify

1. Run:

   ```bash
   node --test tests/http-util.test.js
   ```

2. Start CliDeck on a specific local interface:

   ```bash
   node server.js --host <local-interface-address>
   ```

3. Create a session and run `clideck agents` inside it. Confirm the command reaches CliDeck instead of returning the local-request `403`.

4. Confirm a request whose source address differs from the server's local address is still rejected.

Also verified with a real same-interface HTTP connection and the existing provider smoke suites.

## What's out of scope

- No change to the default bind address.
- No proxy-header trust or remote authentication changes.
- No changes to agent-command behavior beyond the same-host request guard.
- No dependency or package changes.

## Checklist

- [x] Tested locally with `node server.js`
- [x] One focused change, not bundled with unrelated fixes
- [x] No new external service dependencies
- [x] Does not read, store, or intercept agent prompts/responses
