### PR TITLE
fix: honor CLIDECK_URL in lifecycle hooks

### DIFF
--- a/bin/claude-hook.js
+++ b/bin/claude-hook.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const http = require('http');
+const { requestHook } = require('./hook-url');
 
 const port = parseInt(process.argv[2], 10);
 const route = process.argv[3];
@@ -20,10 +20,7 @@ process.stdin.on('end', () => {
     reason: hook.reason || '',
     payload: stdin.trim() || undefined,
   });
-  const req = http.request({
-    hostname: 'localhost',
-    port,
-    path: `/hook/claude/${route}`,
+  const req = requestHook(`/hook/claude/${route}`, port, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) },
     timeout: 2000,

--- a/bin/codex-hook.js
+++ b/bin/codex-hook.js
@@ -2,7 +2,7 @@
 // Silent Codex lifecycle hook for CliDeck.
 // Reads Codex hook JSON from stdin, posts to CliDeck, and intentionally prints nothing.
 
-const http = require('http');
+const { requestHook } = require('./hook-url');
 
 const port = parseInt(process.argv[2], 10);
 const route = String(process.argv[3] || '').replace(/[^a-z]/g, '');
@@ -21,10 +21,7 @@ process.stdin.on('end', () => {
   payload.clideck_id = clideckId || undefined;
   payload.source = 'hook';
 
-  const req = http.request({
-    hostname: 'localhost',
-    port,
-    path: `/hook/codex/${route}`,
+  const req = requestHook(`/hook/codex/${route}`, port, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     timeout: 2000,

--- a/bin/gemini-hook.js
+++ b/bin/gemini-hook.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const http = require('http');
+const { requestHook } = require('./hook-url');
 
 const port = parseInt(process.argv[2], 10);
 const route = process.argv[3];
@@ -17,10 +17,7 @@ process.stdin.on('end', () => {
     session_id: hook.session_id || process.env.GEMINI_SESSION_ID || '',
     payload: stdin.trim() || undefined,
   });
-  const req = http.request({
-    hostname: 'localhost',
-    port,
-    path: `/hook/gemini/${route}`,
+  const req = requestHook(`/hook/gemini/${route}`, port, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) },
     timeout: 2000,

--- a/bin/hook-url.js
+++ b/bin/hook-url.js
@@ -1,0 +1,24 @@
+const http = require('http');
+const https = require('https');
+
+function resolveHookUrl(path, port, rawUrl = process.env.CLIDECK_URL) {
+  const fallback = new URL(`http://localhost:${port}`);
+  let base = fallback;
+
+  if (rawUrl) {
+    try {
+      const parsed = new URL(rawUrl);
+      if (parsed.protocol === 'http:' || parsed.protocol === 'https:') base = parsed;
+    } catch {}
+  }
+
+  return new URL(path, base);
+}
+
+function requestHook(path, port, options) {
+  const target = resolveHookUrl(path, port);
+  const client = target.protocol === 'https:' ? https : http;
+  return client.request(target, options);
+}
+
+module.exports = { resolveHookUrl, requestHook };

--- a/bin/notify-helper.js
+++ b/bin/notify-helper.js
@@ -4,6 +4,8 @@
 // Codex appends the JSON payload as the last argv argument.
 // Port is passed as the first argument by the notify config.
 
+const { requestHook } = require('./hook-url');
+
 const port = parseInt(process.argv[2], 10);
 const raw = process.argv[process.argv.length - 1];
 const clideckId = process.env.CLIDECK_SESSION_ID || '';
@@ -15,9 +17,7 @@ try {
   payload = JSON.stringify({ ...parsed, clideck_id: clideckId || undefined });
 } catch {}
 
-const http = require('http');
-const req = http.request({
-  hostname: 'localhost', port, path: '/hook/codex/stop',
+const req = requestHook('/hook/codex/stop', port, {
   method: 'POST', headers: { 'Content-Type': 'application/json' },
   timeout: 2000,
 });

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "smoke:menu-status": "node tests/providers/menu-status.test.js",
     "smoke:codex-config": "node tests/providers/codex-config.test.js",
     "smoke:codex-hooks": "node tests/providers/codex-hooks.test.js",
-    "smoke:http-util": "node --test tests/http-util.test.js"
+    "smoke:http-util": "node --test tests/http-util.test.js",
+    "smoke:hook-url": "node --test tests/hook-url.test.js"
   },
   "keywords": [
     "terminal",

--- a/tests/hook-url.test.js
+++ b/tests/hook-url.test.js
@@ -1,0 +1,102 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('http');
+const { spawn } = require('child_process');
+const { join } = require('path');
+
+const { resolveHookUrl } = require('../bin/hook-url');
+
+const BIN_DIR = join(__dirname, '..', 'bin');
+const HOST = '127.0.0.2';
+
+function runHelper(file, args, input, env) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [join(BIN_DIR, file), ...args], {
+      env: { ...process.env, ...env },
+      stdio: ['pipe', 'ignore', 'pipe'],
+    });
+    let stderr = '';
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', chunk => { stderr += chunk; });
+    child.on('error', reject);
+    child.on('exit', code => {
+      if (code === 0) resolve();
+      else reject(new Error(`${file} exited ${code}: ${stderr}`));
+    });
+    child.stdin.end(input || '');
+  });
+}
+
+function waitForRequest(server) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('timed out waiting for hook request')), 3000);
+    server.once('request', (req, res) => {
+      let body = '';
+      req.setEncoding('utf8');
+      req.on('data', chunk => { body += chunk; });
+      req.on('end', () => {
+        clearTimeout(timer);
+        res.writeHead(200, { Connection: 'close' });
+        res.end('{}');
+        resolve({ path: req.url, body });
+      });
+    });
+  });
+}
+
+function listen(server, host) {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, host, () => resolve(server.address().port));
+  });
+}
+
+function close(server) {
+  return new Promise(resolve => server.close(resolve));
+}
+
+test('resolves valid CLIDECK_URL values and falls back for absent or invalid values', () => {
+  assert.equal(resolveHookUrl('/hook/test', 4000, '').href, 'http://localhost:4000/hook/test');
+  assert.equal(resolveHookUrl('/hook/test', 4000, 'not a URL').href, 'http://localhost:4000/hook/test');
+  assert.equal(resolveHookUrl('/hook/test', 4000, 'ftp://example.test:21').href, 'http://localhost:4000/hook/test');
+  assert.equal(resolveHookUrl('/hook/test', 4000, 'http://127.0.0.2:4555/base').href, 'http://127.0.0.2:4555/hook/test');
+  assert.equal(resolveHookUrl('/hook/test', 4000, 'https://example.test/base').href, 'https://example.test/hook/test');
+  assert.equal(resolveHookUrl('/hook/test', 4000, 'http://[::1]:4555').href, 'http://[::1]:4555/hook/test');
+});
+
+test('all lifecycle helpers post through CLIDECK_URL', async () => {
+  const server = http.createServer();
+  let fallbackRequests = 0;
+  const fallbackServer = http.createServer((req, res) => {
+    fallbackRequests++;
+    res.writeHead(200, { Connection: 'close' });
+    res.end('{}');
+  });
+  const port = await listen(server, HOST);
+  const fallbackPort = await listen(fallbackServer, '127.0.0.1');
+  const payload = JSON.stringify({ session_id: 'agent-session' });
+  const env = {
+    CLIDECK_URL: `http://${HOST}:${port}`,
+    CLIDECK_SESSION_ID: 'clideck-session',
+  };
+  const cases = [
+    { file: 'claude-hook.js', args: [String(fallbackPort), 'start'], input: payload, path: '/hook/claude/start' },
+    { file: 'gemini-hook.js', args: [String(fallbackPort), 'start'], input: payload, path: '/hook/gemini/start' },
+    { file: 'codex-hook.js', args: [String(fallbackPort), 'start'], input: payload, path: '/hook/codex/start' },
+    { file: 'notify-helper.js', args: [String(fallbackPort), payload], input: '', path: '/hook/codex/stop' },
+  ];
+
+  try {
+    for (const item of cases) {
+      const [request] = await Promise.all([
+        waitForRequest(server),
+        runHelper(item.file, item.args, item.input, env),
+      ]);
+      assert.equal(request.path, item.path, item.file);
+      assert.equal(JSON.parse(request.body).clideck_id, 'clideck-session', item.file);
+    }
+    assert.equal(fallbackRequests, 0);
+  } finally {
+    await Promise.all([close(server), close(fallbackServer)]);
+  }
+});


### PR DESCRIPTION
## What changed

Route the Claude, Gemini, and Codex lifecycle helpers through `CLIDECK_URL`, falling back to localhost when it is absent or invalid.

A shared resolver supports HTTP and HTTPS and is covered by a focused smoke test that executes all four affected helpers.

## Why

CliDeck passes its interface-specific URL to managed sessions, but these helpers still posted to localhost. On a specific-interface bind, lifecycle events therefore missed the CliDeck server.

## How to verify

```bash
npm run smoke:hook-url
npm run smoke:http-util
npm run smoke:codex-hooks
npm run smoke:codex-config
```

The regression test binds only to `127.0.0.2` and confirms each helper uses the host and port from `CLIDECK_URL`.

## What's out of scope

- No changes to Codex's OTel endpoint.
- No changes to session matching or issue #28.
- No changes to bind defaults, authentication, or hook payloads.
